### PR TITLE
Add decimal vitals formatting and conditional styling

### DIFF
--- a/DHP2_DeployDraft1.7.6/scripts/app.js
+++ b/DHP2_DeployDraft1.7.6/scripts/app.js
@@ -3270,55 +3270,94 @@ const SEASON_META_HEADERS = {
         }
 
         function getPlayerVitals(playerId) {
-            const fallback = { age: '—', height: '—', weight: '—' };
             const playerData = state.players?.[playerId];
-            if (!playerData) return fallback;
+            if (!playerData) {
+                return {
+                    age: { display: '—', numeric: null },
+                    height: { display: '—', numeric: null },
+                    weight: { display: '—', numeric: null },
+                    exp: '—',
+                    ry: '—',
+                    position: null
+                };
+            }
 
             const collect = (...values) => values
                 .map(value => (typeof value === 'string' ? value.trim() : value))
                 .filter(value => value !== undefined && value !== null && value !== '');
 
+            const toNumber = (value) => {
+                if (value === null || value === undefined) return null;
+                const numeric = Number(value);
+                return Number.isFinite(numeric) ? numeric : null;
+            };
+
+            const clampDisplayNumber = (numeric, decimals = 1) => {
+                if (!Number.isFinite(numeric)) return null;
+                const rounded = Number.parseFloat(numeric.toFixed(decimals));
+                return {
+                    display: rounded.toFixed(decimals),
+                    numeric: rounded
+                };
+            };
+
+            const getSheetAge = () => {
+                const valueData = state.isSuperflex ? state.sflxData?.[playerId] : state.oneQbData?.[playerId];
+                return valueData?.age;
+            };
+
+            const computeAgeFromBirthdate = () => {
+                const birthdate = playerData.birthdate || playerData.metadata?.birthdate;
+                if (!birthdate) return null;
+                const birth = new Date(birthdate);
+                if (Number.isNaN(birth.getTime())) return null;
+                const today = new Date();
+                const diffMs = today.getTime() - birth.getTime();
+                if (diffMs <= 0) return null;
+                const age = diffMs / (365.2425 * 24 * 60 * 60 * 1000);
+                if (!Number.isFinite(age) || age <= 0 || age >= 80) return null;
+                return clampDisplayNumber(age, 1);
+            };
+
             const parseAge = () => {
-                const candidates = collect(
+                const ageCandidates = collect(
+                    getSheetAge(),
                     playerData.age,
                     playerData.metadata?.age,
                     playerData.metadata?.player_age
                 );
 
-                for (const candidate of candidates) {
-                    const numeric = Number.parseInt(candidate, 10);
-                    if (Number.isFinite(numeric) && numeric > 0) {
-                        return String(numeric);
+                for (const candidate of ageCandidates) {
+                    const numeric = toNumber(candidate);
+                    if (numeric !== null && numeric > 0 && numeric < 80) {
+                        return clampDisplayNumber(numeric, 1);
                     }
                 }
 
-                if (playerData.birthdate) {
-                    const birth = new Date(playerData.birthdate);
-                    if (!Number.isNaN(birth.getTime())) {
-                        const today = new Date();
-                        let age = today.getFullYear() - birth.getFullYear();
-                        const hasHadBirthdayThisYear =
-                            today.getMonth() > birth.getMonth() ||
-                            (today.getMonth() === birth.getMonth() && today.getDate() >= birth.getDate());
-                        if (!hasHadBirthdayThisYear) age -= 1;
-                        if (Number.isFinite(age) && age > 0 && age < 80) {
-                            return String(age);
-                        }
-                    }
-                }
-
-                return null;
+                return computeAgeFromBirthdate();
             };
 
-            const formatHeightFromParts = (feet, inches) => {
+            const heightFromTotalInches = (totalInches) => {
+                if (!Number.isFinite(totalInches) || totalInches <= 0) return null;
+                const rounded = Math.round(totalInches);
+                const feet = Math.floor(rounded / 12);
+                const inches = rounded % 12;
+                if (feet <= 0) return null;
+                return {
+                    display: `${feet}'${inches}"`,
+                    numeric: rounded
+                };
+            };
+
+            const totalInchesFromParts = (feet, inches) => {
                 const f = Number.parseInt(feet, 10);
                 const i = Number.parseInt(inches, 10);
                 if (!Number.isFinite(f) && !Number.isFinite(i)) return null;
-                const safeFeet = Number.isFinite(f) ? f : Math.floor(i / 12);
-                const safeInches = Number.isFinite(i) ? i % 12 : 0;
-                if (!Number.isFinite(safeFeet) || safeFeet <= 0) return null;
-                const boundedInches = Math.max(0, Math.min(11, safeInches));
-                return `${safeFeet}'${boundedInches}"`;
+                let total = 0;
+                if (Number.isFinite(f)) total += f * 12;
+                if (Number.isFinite(i)) total += i;
+                if (!Number.isFinite(f) && Number.isFinite(i)) total = i;
+                return total > 0 ? total : null;
             };
 
             const parseHeightString = (value) => {
@@ -3328,28 +3367,33 @@ const SEASON_META_HEADERS = {
 
                 const digits = str.match(/\d+/g);
                 if (!digits || digits.length === 0) return null;
+
                 if (digits.length >= 2) {
-                    return formatHeightFromParts(digits[0], digits[1]);
+                    const total = totalInchesFromParts(digits[0], digits[1]);
+                    const formatted = heightFromTotalInches(total);
+                    if (formatted) return formatted;
+                }
+
+                const raw = digits.join('');
+                if (raw.length >= 3) {
+                    const feetPart = raw.slice(0, raw.length - 2);
+                    const inchPart = raw.slice(-2);
+                    const total = totalInchesFromParts(feetPart, inchPart);
+                    const formatted = heightFromTotalInches(total);
+                    if (formatted) return formatted;
                 }
 
                 const only = Number.parseInt(digits[0], 10);
                 if (!Number.isFinite(only) || only <= 0) return null;
-
-                const raw = digits[0];
-                if (raw.length >= 3) {
-                    const feetPart = raw.slice(0, raw.length - 2);
-                    const inchPart = raw.slice(-2);
-                    const formattedFromRaw = formatHeightFromParts(feetPart, inchPart);
-                    if (formattedFromRaw) return formattedFromRaw;
-                }
-
                 if (only > 12) {
-                    const feet = Math.floor(only / 12);
-                    const inches = only % 12;
-                    return `${feet}'${inches}"`;
+                    const formatted = heightFromTotalInches(only);
+                    if (formatted) return formatted;
                 }
 
-                return `${only}'0"`;
+                const formatted = heightFromTotalInches(totalInchesFromParts(only, 0));
+                if (formatted) return formatted;
+
+                return null;
             };
 
             const parseHeight = () => {
@@ -3360,7 +3404,8 @@ const SEASON_META_HEADERS = {
                     [playerData.metadata?.height_ft, playerData.metadata?.height_in]
                 ];
                 for (const [feet, inches] of pairCandidates) {
-                    const formatted = formatHeightFromParts(feet, inches);
+                    const total = totalInchesFromParts(feet, inches);
+                    const formatted = heightFromTotalInches(total);
                     if (formatted) return formatted;
                 }
 
@@ -3392,9 +3437,13 @@ const SEASON_META_HEADERS = {
                 );
 
                 for (const candidate of weightCandidates) {
-                    const numeric = Number.parseInt(candidate, 10);
-                    if (Number.isFinite(numeric) && numeric > 0) {
-                        return `${numeric} lbs`;
+                    const numeric = toNumber(candidate);
+                    if (numeric !== null && numeric > 0) {
+                        const rounded = Math.round(numeric);
+                        return {
+                            display: `${rounded} lbs`,
+                            numeric: rounded
+                        };
                     }
                 }
 
@@ -3420,12 +3469,127 @@ const SEASON_META_HEADERS = {
             };
 
             return {
-                age: parseAge() ?? '—',
-                height: parseHeight() ?? '—',
-                weight: parseWeight() ?? '—',
+                age: parseAge() ?? { display: '—', numeric: null },
+                height: parseHeight() ?? { display: '—', numeric: null },
+                weight: parseWeight() ?? { display: '—', numeric: null },
                 exp: parseYearsExperience(),
-                ry: parseRookieYear()
+                ry: parseRookieYear(),
+                position: playerData.position || playerData.fantasy_positions?.[0] || null
             };
+        }
+
+        const VITALS_CONDITIONAL_RULES = {
+            AGE: {
+                'WR|TE': [
+                    { op: '<', value: 23.5, color: '#cefcf1' },
+                    { op: '<', value: 26.5, color: '#a0f0f9' },
+                    { op: '<', value: 29.0, color: '#c3c9ff' },
+                    { op: '<', value: 31.0, color: '#dfbbfe' },
+                    { op: '>=', value: 31.0, color: '#ffb8f4' }
+                ],
+                RB: [
+                    { op: '<', value: 23.0, color: '#cefcf1' },
+                    { op: '<', value: 25.0, color: '#a0f0f9' },
+                    { op: '<', value: 26.5, color: '#c3c9ff' },
+                    { op: '<', value: 28.0, color: '#dfbbfe' },
+                    { op: '>=', value: 28.0, color: '#ffb8f4' }
+                ],
+                QB: [
+                    { op: '<', value: 25.5, color: '#cefcf1' },
+                    { op: '<', value: 29.0, color: '#a0f0f9' },
+                    { op: '<', value: 33.5, color: '#c3c9ff' },
+                    { op: '<', value: 38.0, color: '#dfbbfe' },
+                    { op: '>=', value: 38.0, color: '#ffb8f4' }
+                ]
+            },
+            WEIGHT_lbs: {
+                QB: [
+                    { op: '<', value: 210, color: '#ffb8f4' },
+                    { op: '>', value: 250, color: '#ffb8f4' },
+                    { op: '>=', value: 210, color: '#c3efff' }
+                ],
+                RB: [
+                    { op: '<', value: 190, color: '#ffb8f4' },
+                    { op: '<', value: 200, color: '#c3c9ff' },
+                    { op: '>=', value: 200, color: '#cefcf1' }
+                ],
+                TE: [
+                    { op: '<', value: 230, color: '#ffb8f4' },
+                    { op: '<', value: 240, color: '#c3c9ff' },
+                    { op: '>=', value: 240, color: '#cefcf1' }
+                ],
+                WR: [
+                    { op: '<', value: 190, color: '#ffb8f4' },
+                    { op: '>=', value: 235, color: '#ffb8f4' },
+                    { op: '>=', value: 198, color: '#cefcf1' },
+                    { op: '>=', value: 190, color: '#c3c9ff' }
+                ]
+            },
+            HEIGHT_in: {
+                QB: [
+                    { op: '<', value: 72, color: '#ffb8f4' },
+                    { op: '>', value: 73, color: '#cefcf1' },
+                    { op: '>=', value: 72, color: '#c3c9ff' }
+                ],
+                RB: [
+                    { op: '<', value: 67, color: '#ffb8f4' },
+                    { op: '>=', value: 75, color: '#ffb8f4' },
+                    { op: '>', value: 69, color: '#cefcf1' },
+                    { op: '>=', value: 67, color: '#c3c9ff' }
+                ],
+                TE: [
+                    { op: '<', value: 73, color: '#ffb8f4' },
+                    { op: '>', value: 74, color: '#cefcf1' },
+                    { op: '>=', value: 73, color: '#c3c9ff' }
+                ],
+                WR: [
+                    { op: '<', value: 71, color: '#ffb8f4' },
+                    { op: '>', value: 72, color: '#cefcf1' },
+                    { op: '>=', value: 71, color: '#c3c9ff' }
+                ]
+            }
+        };
+
+        function getConditionalVitalColor(key, position, numericValue) {
+            if (!Number.isFinite(numericValue)) return null;
+            const config = VITALS_CONDITIONAL_RULES[key];
+            if (!config) return null;
+            const normalizedPosition = position ? String(position).toUpperCase() : null;
+
+            const findRules = () => {
+                if (!normalizedPosition) return null;
+                for (const [posKey, rules] of Object.entries(config)) {
+                    const positions = posKey.split('|').map(p => p.trim().toUpperCase());
+                    if (positions.includes(normalizedPosition)) return rules;
+                }
+                return null;
+            };
+
+            const rules = findRules();
+            if (!rules) return null;
+
+            for (const rule of rules) {
+                const threshold = Number(rule.value);
+                if (!Number.isFinite(threshold)) continue;
+                switch (rule.op) {
+                    case '<':
+                        if (numericValue < threshold) return rule.color;
+                        break;
+                    case '<=':
+                        if (numericValue <= threshold) return rule.color;
+                        break;
+                    case '>':
+                        if (numericValue > threshold) return rule.color;
+                        break;
+                    case '>=':
+                        if (numericValue >= threshold) return rule.color;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return null;
         }
 
         function createPlayerVitalsElement(vitals, { variant = 'modal' } = {}) {
@@ -3433,14 +3597,14 @@ const SEASON_META_HEADERS = {
             container.className = `player-vitals player-vitals--${variant}`;
 
             const items = [
-                { label: 'AGE', value: vitals.age },
-                { label: 'HEIGHT', value: vitals.height },
-                { label: 'WEIGHT', value: vitals.weight },
+                { label: 'AGE', value: vitals.age.display, numeric: vitals.age.numeric, ruleKey: 'AGE' },
+                { label: 'HEIGHT', value: vitals.height.display, numeric: vitals.height.numeric, ruleKey: 'HEIGHT_in' },
+                { label: 'WEIGHT', value: vitals.weight.display, numeric: vitals.weight.numeric, ruleKey: 'WEIGHT_lbs' },
                 { label: 'EXP', value: vitals.exp },
                 { label: 'RY', value: vitals.ry }
             ];
 
-            items.forEach(({ label, value }) => {
+            items.forEach(({ label, value, numeric, ruleKey }) => {
                 const item = document.createElement('div');
                 item.className = 'player-vitals__item';
 
@@ -3451,6 +3615,14 @@ const SEASON_META_HEADERS = {
                 const valueEl = document.createElement('span');
                 valueEl.className = 'player-vitals__value';
                 valueEl.textContent = value;
+
+                if (ruleKey && value !== '—') {
+                    const color = getConditionalVitalColor(ruleKey, vitals.position, numeric);
+                    if (color) {
+                        valueEl.style.backgroundColor = color;
+                        valueEl.classList.add('player-vitals__value--highlight');
+                    }
+                }
 
                 item.appendChild(labelEl);
                 item.appendChild(valueEl);

--- a/DHP2_DeployDraft1.7.6/styles/styles.css
+++ b/DHP2_DeployDraft1.7.6/styles/styles.css
@@ -3118,6 +3118,13 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
       line-height: 1;
     }
 
+    .player-vitals__value--highlight {
+      color: #0a1b2e;
+      padding: 0.08rem 0.32rem;
+      border-radius: 4px;
+      line-height: 1.1;
+    }
+
     .player-vitals--modal {
       margin: 0.2rem 0 0.58rem;
     border: 1px solid #ffffff10;


### PR DESCRIPTION
## Summary
- format player vitals age with shared decimal-precision logic and metadata fallbacks
- expose numeric height/weight values and apply position-based conditional color rules
- style highlighted vitals so the new backgrounds remain legible in modals

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d56b3116c8832eb3569d58d9410368