### PR TITLE
Use text colors for vitals highlights

### DIFF
--- a/DHP2_DeployDraft1.7.6/scripts/app.js
+++ b/DHP2_DeployDraft1.7.6/scripts/app.js
@@ -3270,7 +3270,17 @@ const SEASON_META_HEADERS = {
         }
 
         function getPlayerVitals(playerId) {
-            const fallback = { age: '—', height: '—', weight: '—' };
+            const fallback = {
+                age: '—',
+                ageNumeric: null,
+                height: '—',
+                heightInches: null,
+                weight: '—',
+                weightLbs: null,
+                exp: '—',
+                ry: '—',
+                position: null
+            };
             const playerData = state.players?.[playerId];
             if (!playerData) return fallback;
 
@@ -3278,17 +3288,40 @@ const SEASON_META_HEADERS = {
                 .map(value => (typeof value === 'string' ? value.trim() : value))
                 .filter(value => value !== undefined && value !== null && value !== '');
 
+            const valuations = state.isSuperflex
+                ? state.sflxData?.[playerId]
+                : state.oneQbData?.[playerId];
+
+            const positionCandidates = [
+                playerData.position,
+                playerData.metadata?.position,
+                playerData.metadata?.player_position,
+                Array.isArray(playerData.fantasy_positions) ? playerData.fantasy_positions[0] : undefined
+            ];
+
+            let resolvedPosition = null;
+            for (const candidate of positionCandidates) {
+                if (typeof candidate === 'string' && candidate.trim()) {
+                    resolvedPosition = candidate.trim().toUpperCase();
+                    break;
+                }
+            }
+
+            let ageNumeric = null;
             const parseAge = () => {
                 const candidates = collect(
+                    valuations?.age,
                     playerData.age,
                     playerData.metadata?.age,
                     playerData.metadata?.player_age
                 );
 
                 for (const candidate of candidates) {
-                    const numeric = Number.parseInt(candidate, 10);
-                    if (Number.isFinite(numeric) && numeric > 0) {
-                        return String(numeric);
+                    const numeric = Number.parseFloat(candidate);
+                    if (Number.isFinite(numeric) && numeric > 0 && numeric < 80) {
+                        const rounded = Number.parseFloat(numeric.toFixed(1));
+                        ageNumeric = rounded;
+                        return rounded.toFixed(1);
                     }
                 }
 
@@ -3296,13 +3329,12 @@ const SEASON_META_HEADERS = {
                     const birth = new Date(playerData.birthdate);
                     if (!Number.isNaN(birth.getTime())) {
                         const today = new Date();
-                        let age = today.getFullYear() - birth.getFullYear();
-                        const hasHadBirthdayThisYear =
-                            today.getMonth() > birth.getMonth() ||
-                            (today.getMonth() === birth.getMonth() && today.getDate() >= birth.getDate());
-                        if (!hasHadBirthdayThisYear) age -= 1;
-                        if (Number.isFinite(age) && age > 0 && age < 80) {
-                            return String(age);
+                        const diffMs = today.getTime() - birth.getTime();
+                        const years = diffMs / (365.2425 * 24 * 60 * 60 * 1000);
+                        if (Number.isFinite(years) && years > 0 && years < 80) {
+                            const rounded = Number.parseFloat(years.toFixed(1));
+                            ageNumeric = rounded;
+                            return rounded.toFixed(1);
                         }
                     }
                 }
@@ -3310,15 +3342,24 @@ const SEASON_META_HEADERS = {
                 return null;
             };
 
-            const formatHeightFromParts = (feet, inches) => {
+            const buildHeightResultFromParts = (feet, inches) => {
                 const f = Number.parseInt(feet, 10);
                 const i = Number.parseInt(inches, 10);
-                if (!Number.isFinite(f) && !Number.isFinite(i)) return null;
-                const safeFeet = Number.isFinite(f) ? f : Math.floor(i / 12);
-                const safeInches = Number.isFinite(i) ? i % 12 : 0;
-                if (!Number.isFinite(safeFeet) || safeFeet <= 0) return null;
-                const boundedInches = Math.max(0, Math.min(11, safeInches));
-                return `${safeFeet}'${boundedInches}"`;
+                const hasFeet = Number.isFinite(f);
+                const hasInches = Number.isFinite(i);
+                if (!hasFeet && !hasInches) return null;
+
+                const derivedFeet = hasFeet ? f : Math.floor(i / 12);
+                if (!Number.isFinite(derivedFeet) || derivedFeet <= 0) return null;
+
+                const normalizedInches = hasInches ? i % 12 : 0;
+                const boundedInches = Math.max(0, Math.min(11, normalizedInches));
+                const totalInches = derivedFeet * 12 + boundedInches;
+
+                return {
+                    display: `${derivedFeet}'${boundedInches}"`,
+                    inches: totalInches
+                };
             };
 
             const parseHeightString = (value) => {
@@ -3329,7 +3370,7 @@ const SEASON_META_HEADERS = {
                 const digits = str.match(/\d+/g);
                 if (!digits || digits.length === 0) return null;
                 if (digits.length >= 2) {
-                    return formatHeightFromParts(digits[0], digits[1]);
+                    return buildHeightResultFromParts(digits[0], digits[1]);
                 }
 
                 const only = Number.parseInt(digits[0], 10);
@@ -3339,17 +3380,18 @@ const SEASON_META_HEADERS = {
                 if (raw.length >= 3) {
                     const feetPart = raw.slice(0, raw.length - 2);
                     const inchPart = raw.slice(-2);
-                    const formattedFromRaw = formatHeightFromParts(feetPart, inchPart);
+                    const formattedFromRaw = buildHeightResultFromParts(feetPart, inchPart);
                     if (formattedFromRaw) return formattedFromRaw;
                 }
 
                 if (only > 12) {
                     const feet = Math.floor(only / 12);
                     const inches = only % 12;
-                    return `${feet}'${inches}"`;
+                    const formattedFromTotal = buildHeightResultFromParts(feet, inches);
+                    if (formattedFromTotal) return formattedFromTotal;
                 }
 
-                return `${only}'0"`;
+                return buildHeightResultFromParts(only, 0);
             };
 
             const parseHeight = () => {
@@ -3360,7 +3402,7 @@ const SEASON_META_HEADERS = {
                     [playerData.metadata?.height_ft, playerData.metadata?.height_in]
                 ];
                 for (const [feet, inches] of pairCandidates) {
-                    const formatted = formatHeightFromParts(feet, inches);
+                    const formatted = buildHeightResultFromParts(feet, inches);
                     if (formatted) return formatted;
                 }
 
@@ -3392,9 +3434,13 @@ const SEASON_META_HEADERS = {
                 );
 
                 for (const candidate of weightCandidates) {
-                    const numeric = Number.parseInt(candidate, 10);
+                    const numeric = Number.parseFloat(candidate);
                     if (Number.isFinite(numeric) && numeric > 0) {
-                        return `${numeric} lbs`;
+                        const rounded = Math.round(numeric);
+                        return {
+                            display: `${rounded} lbs`,
+                            lbs: rounded
+                        };
                     }
                 }
 
@@ -3419,13 +3465,139 @@ const SEASON_META_HEADERS = {
                 return '—';
             };
 
+            const ageDisplay = parseAge();
+            const heightResult = parseHeight();
+            const weightResult = parseWeight();
+
             return {
-                age: parseAge() ?? '—',
-                height: parseHeight() ?? '—',
-                weight: parseWeight() ?? '—',
+                position: resolvedPosition,
+                age: ageDisplay ?? '—',
+                ageNumeric,
+                height: heightResult?.display ?? '—',
+                heightInches: heightResult?.inches ?? null,
+                weight: weightResult?.display ?? '—',
+                weightLbs: weightResult?.lbs ?? null,
                 exp: parseYearsExperience(),
                 ry: parseRookieYear()
             };
+        }
+
+        const VITALS_CONDITIONAL_COLORS = {
+            AGE: {
+                WR: [
+                    { op: '<', value: 23.5, color: '#cefcf1' },
+                    { op: '<', value: 26.5, color: '#a0f0f9' },
+                    { op: '<', value: 29.0, color: '#c3c9ff' },
+                    { op: '<', value: 31.0, color: '#dfbbfe' },
+                    { op: '>=', value: 31.0, color: '#ffb8f4' }
+                ],
+                TE: [
+                    { op: '<', value: 23.5, color: '#cefcf1' },
+                    { op: '<', value: 26.5, color: '#a0f0f9' },
+                    { op: '<', value: 29.0, color: '#c3c9ff' },
+                    { op: '<', value: 31.0, color: '#dfbbfe' },
+                    { op: '>=', value: 31.0, color: '#ffb8f4' }
+                ],
+                RB: [
+                    { op: '<', value: 23.0, color: '#cefcf1' },
+                    { op: '<', value: 25.0, color: '#a0f0f9' },
+                    { op: '<', value: 26.5, color: '#c3c9ff' },
+                    { op: '<', value: 28.0, color: '#dfbbfe' },
+                    { op: '>=', value: 28.0, color: '#ffb8f4' }
+                ],
+                QB: [
+                    { op: '<', value: 25.5, color: '#cefcf1' },
+                    { op: '<', value: 29.0, color: '#a0f0f9' },
+                    { op: '<', value: 33.5, color: '#c3c9ff' },
+                    { op: '<', value: 38.0, color: '#dfbbfe' },
+                    { op: '>=', value: 38.0, color: '#ffb8f4' }
+                ]
+            },
+            WEIGHT_lbs: {
+                QB: [
+                    { op: '<', value: 210, color: '#ffb8f4' },
+                    { op: '>', value: 250, color: '#ffb8f4' },
+                    { op: '>=', value: 210, color: '#c3efff' }
+                ],
+                RB: [
+                    { op: '<', value: 190, color: '#ffb8f4' },
+                    { op: '<', value: 200, color: '#c3c9ff' },
+                    { op: '>=', value: 200, color: '#cefcf1' }
+                ],
+                TE: [
+                    { op: '<', value: 230, color: '#ffb8f4' },
+                    { op: '<', value: 240, color: '#c3c9ff' },
+                    { op: '>=', value: 240, color: '#cefcf1' }
+                ],
+                WR: [
+                    { op: '<', value: 190, color: '#ffb8f4' },
+                    { op: '>=', value: 235, color: '#ffb8f4' },
+                    { op: '>=', value: 198, color: '#cefcf1' },
+                    { op: '>=', value: 190, color: '#c3c9ff' }
+                ]
+            },
+            HEIGHT_in: {
+                QB: [
+                    { op: '<', value: 72, color: '#ffb8f4' },
+                    { op: '>', value: 73, color: '#cefcf1' },
+                    { op: '>=', value: 72, color: '#c3c9ff' }
+                ],
+                RB: [
+                    { op: '<', value: 67, color: '#ffb8f4' },
+                    { op: '>=', value: 75, color: '#ffb8f4' },
+                    { op: '>', value: 69, color: '#cefcf1' },
+                    { op: '>=', value: 67, color: '#c3c9ff' }
+                ],
+                TE: [
+                    { op: '<', value: 73, color: '#ffb8f4' },
+                    { op: '>', value: 74, color: '#cefcf1' },
+                    { op: '>=', value: 73, color: '#c3c9ff' }
+                ],
+                WR: [
+                    { op: '<', value: 71, color: '#ffb8f4' },
+                    { op: '>', value: 72, color: '#cefcf1' },
+                    { op: '>=', value: 71, color: '#c3c9ff' }
+                ]
+            }
+        };
+
+        function evaluateConditionalColor(rules, numericValue) {
+            if (!rules || !Number.isFinite(numericValue)) return null;
+            for (const rule of rules) {
+                if (rule.op === '<' && numericValue < rule.value) return rule.color;
+                if (rule.op === '>' && numericValue > rule.value) return rule.color;
+                if (rule.op === '>=' && numericValue >= rule.value) return rule.color;
+            }
+            return null;
+        }
+
+        function getVitalsConditionalColor(label, vitals) {
+            const position = vitals.position;
+            if (!position) return null;
+
+            let typeKey = null;
+            let numericValue = null;
+
+            if (label === 'AGE') {
+                typeKey = 'AGE';
+                numericValue = vitals.ageNumeric;
+            } else if (label === 'HEIGHT') {
+                typeKey = 'HEIGHT_in';
+                numericValue = vitals.heightInches;
+            } else if (label === 'WEIGHT') {
+                typeKey = 'WEIGHT_lbs';
+                numericValue = vitals.weightLbs;
+            } else {
+                return null;
+            }
+
+            if (!Number.isFinite(numericValue)) return null;
+
+            const positionKey = position.toUpperCase();
+            const rules = VITALS_CONDITIONAL_COLORS[typeKey]?.[positionKey];
+            if (!rules) return null;
+
+            return evaluateConditionalColor(rules, numericValue);
         }
 
         function createPlayerVitalsElement(vitals, { variant = 'modal' } = {}) {
@@ -3451,6 +3623,11 @@ const SEASON_META_HEADERS = {
                 const valueEl = document.createElement('span');
                 valueEl.className = 'player-vitals__value';
                 valueEl.textContent = value;
+
+                const textColor = getVitalsConditionalColor(label, vitals);
+                if (textColor) {
+                    valueEl.style.color = textColor;
+                }
 
                 item.appendChild(labelEl);
                 item.appendChild(valueEl);


### PR DESCRIPTION
## Summary
- update player vitals rendering to apply conditional highlight colors to the value text instead of the background

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5718651a0832e860acc8ffe874a7c