### PR TITLE
Recenter stat labels in player comparison table

### DIFF
--- a/DHP2_DeployDraft1.7.6/scripts/app.js
+++ b/DHP2_DeployDraft1.7.6/scripts/app.js
@@ -2345,18 +2345,26 @@ const wrTeStatOrder = [
 
             // Table Header
             const tr = document.createElement('tr');
-            const statTh = document.createElement('th');
-            statTh.textContent = 'STAT';
-            statTh.className = 'stat-header';
-            tr.appendChild(statTh);
-            players.forEach(player => {
+            players.forEach((player, index) => {
                 const fullPlayer = state.players[player.id];
                 const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.label;
                 const th = document.createElement('th');
                 th.className = 'player-header';
                 th.innerHTML = `<h4>${playerName}</h4>`;
                 tr.appendChild(th);
+                if (index === 0) {
+                    const statTh = document.createElement('th');
+                    statTh.textContent = 'STAT';
+                    statTh.className = 'stat-header';
+                    tr.appendChild(statTh);
+                }
             });
+            if (players.length === 0) {
+                const statTh = document.createElement('th');
+                statTh.textContent = 'STAT';
+                statTh.className = 'stat-header';
+                tr.appendChild(statTh);
+            }
             thead.appendChild(tr);
 
             // Table Body
@@ -2454,7 +2462,9 @@ const wrTeStatOrder = [
             for (const statKey of orderedStatKeys) {
                 if (statLabels[statKey]) {
                     const row = document.createElement('tr');
-                    row.innerHTML = `<td>${statLabels[statKey]}</td>`;
+                    const labelCell = document.createElement('td');
+                    labelCell.textContent = statLabels[statKey];
+                    labelCell.className = 'stat-label-cell';
 
                     let bestValue = -Infinity;
                     let bestValueIndices = [];
@@ -2684,6 +2694,7 @@ const wrTeStatOrder = [
 
                     displayValues.forEach((val, i) => {
                         const td = document.createElement('td');
+                        td.classList.add('player-stat-cell');
                         td.textContent = val;
                         const rankAnnotation = rankAnnotations[i];
                         if (rankAnnotation) {
@@ -2705,7 +2716,12 @@ const wrTeStatOrder = [
                                 }
                             }
                         }
-                        row.appendChild(td);
+                        if (i === 0) {
+                            row.appendChild(td);
+                            row.appendChild(labelCell);
+                        } else {
+                            row.appendChild(td);
+                        }
                     });
 
                     tbody.appendChild(row);

--- a/DHP2_DeployDraft1.7.6/styles/styles.css
+++ b/DHP2_DeployDraft1.7.6/styles/styles.css
@@ -3707,10 +3707,21 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
         padding: 0.5rem 0.25rem;
     }
     .player-comparison-table thead .stat-header {
-        width: 30%;
+        width: 22%;
     }
     .player-comparison-table thead .player-header {
-        width: 35%;
+        width: 39%;
+    }
+
+    .player-comparison-table .stat-label-cell {
+        width: 22%;
+        font-weight: 600;
+        color: rgba(224, 226, 246, 0.85);
+        white-space: normal;
+    }
+
+    .player-comparison-table .player-stat-cell {
+        width: 39%;
     }
     
     .player-comparison-table tbody tr:nth-child(odd) {
@@ -3951,11 +3962,19 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     }
 
     .player-comparison-table thead .stat-header {
-        width: 30%;
+        width: 24%;
     }
 
     .player-comparison-table thead .player-header {
-        width: 35%;
+        width: 38%;
+    }
+
+    .player-comparison-table .stat-label-cell {
+        width: 24%;
+    }
+
+    .player-comparison-table .player-stat-cell {
+        width: 38%;
     }
 
     #player-comparison-modal .player-comparison-table th,


### PR DESCRIPTION
## Summary
- update the player comparison modal so each stat label renders between the two player value columns
- tweak comparison table styles so player columns stay wider than the centered label on desktop and mobile widths

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5db88ced0832eb4a36c71f33ca16c