### PR TITLE
Improve analyzer chips and modal vitals responsiveness

### DIFF
--- a/DHP2_DeployDraft1.9D/scripts/analyzer.js
+++ b/DHP2_DeployDraft1.9D/scripts/analyzer.js
@@ -1010,6 +1010,11 @@
       const standingsOrder = sortTeamsByStandings(teams);
       const overallRank = computeRank(standingsOrder, (team) => team.isUserTeam);
 
+      const totalValueRank = computeRank(
+        [...teams].sort((a, b) => (b.totalValue || 0) - (a.totalValue || 0)),
+        (team) => team.isUserTeam,
+      );
+
       const starterValueRank = computeRank(
         [...teams].sort((a, b) => b.startersValueTotal - a.startersValueTotal),
         (team) => team.isUserTeam,
@@ -1051,7 +1056,13 @@
         {
           label: 'TTL Team Value',
           value: formatNumber(userTeam.totalValue),
-          meta: 'KTC',
+          meta: [
+            totalValueRank ? `Rank ${totalValueRank}/${totalTeams}` : totalTeams ? 'Rank NA' : null,
+            'KTC',
+          ]
+            .filter(Boolean)
+            .join(' • '),
+          accent: totalValueRank ? getRankColor(totalValueRank, totalTeams) : undefined,
         },
         {
           label: 'Starter Value',
@@ -1096,6 +1107,9 @@
     function renderLineupChart(teams) {
       state.lineupData = buildLineupDatasets(teams);
       if (state.charts.lineup) {
+        if (typeof state.charts.lineup.$cleanup === 'function') {
+          state.charts.lineup.$cleanup();
+        }
         state.charts.lineup.destroy();
       }
       const metricConfig = state.lineupData[state.currentLineupMetric];
@@ -1291,15 +1305,70 @@
     }
 
     function createStackedBarChart(canvas, labels, datasets, options) {
-      return new Chart(canvas, {
+      const chart = new Chart(canvas, {
         type: 'bar',
         data: { labels, datasets },
         options,
       });
+
+      const canvasEl = chart.canvas;
+      if (!canvasEl) {
+        return chart;
+      }
+
+      const clearActiveElements = () => {
+        if (!chart) return;
+        const hasActive = typeof chart.getActiveElements === 'function'
+          ? chart.getActiveElements().length > 0
+          : Array.isArray(chart._active) && chart._active.length > 0;
+        const tooltip = chart.tooltip;
+        const tooltipActive =
+          typeof tooltip?.getActiveElements === 'function'
+            ? tooltip.getActiveElements().length > 0
+            : Array.isArray(tooltip?.active) && tooltip.active.length > 0;
+        if (!hasActive && !tooltipActive) return;
+
+        chart.setActiveElements([]);
+        if (tooltip && typeof tooltip.setActiveElements === 'function') {
+          tooltip.setActiveElements([], { x: 0, y: 0 });
+        }
+        chart.update('none');
+      };
+
+      const handleCanvasPointerDown = (event) => {
+        const elements = chart.getElementsAtEventForMode(
+          event,
+          'nearest',
+          { intersect: true },
+          false,
+        );
+        if (!elements.length) {
+          clearActiveElements();
+        }
+      };
+
+      const handleDocumentPointerDown = (event) => {
+        if (canvasEl.contains(event.target)) return;
+        clearActiveElements();
+      };
+
+      const listenerOptions = { passive: true };
+      canvasEl.addEventListener('pointerdown', handleCanvasPointerDown, listenerOptions);
+      document.addEventListener('pointerdown', handleDocumentPointerDown, listenerOptions);
+
+      chart.$cleanup = () => {
+        canvasEl.removeEventListener('pointerdown', handleCanvasPointerDown, listenerOptions);
+        document.removeEventListener('pointerdown', handleDocumentPointerDown, listenerOptions);
+      };
+
+      return chart;
     }
 
     function renderOverallChart(teams) {
       if (state.charts.overall) {
+        if (typeof state.charts.overall.$cleanup === 'function') {
+          state.charts.overall.$cleanup();
+        }
         state.charts.overall.destroy();
       }
 

--- a/DHP2_DeployDraft1.9D/scripts/app.js
+++ b/DHP2_DeployDraft1.9D/scripts/app.js
@@ -3427,11 +3427,26 @@ const wrTeStatOrder = [
             const playerData = state.players?.[playerId];
             if (!playerData) return fallback;
 
+            const valueData = state.isSuperflex
+                ? state.sflxData?.[playerId]
+                : state.oneQbData?.[playerId];
+
             const collect = (...values) => values
                 .map(value => (typeof value === 'string' ? value.trim() : value))
                 .filter(value => value !== undefined && value !== null && value !== '');
 
             const parseAge = () => {
+                const ageFromValues = valueData?.age;
+                if (typeof ageFromValues === 'number' && Number.isFinite(ageFromValues)) {
+                    return ageFromValues.toFixed(1);
+                }
+                if (typeof ageFromValues === 'string') {
+                    const numericAge = Number.parseFloat(ageFromValues);
+                    if (Number.isFinite(numericAge)) {
+                        return numericAge.toFixed(1);
+                    }
+                }
+
                 const candidates = collect(
                     playerData.age,
                     playerData.metadata?.age,
@@ -3439,9 +3454,9 @@ const wrTeStatOrder = [
                 );
 
                 for (const candidate of candidates) {
-                    const numeric = Number.parseInt(candidate, 10);
+                    const numeric = Number.parseFloat(candidate);
                     if (Number.isFinite(numeric) && numeric > 0) {
-                        return String(numeric);
+                        return numeric.toFixed(1);
                     }
                 }
 
@@ -3449,13 +3464,10 @@ const wrTeStatOrder = [
                     const birth = new Date(playerData.birthdate);
                     if (!Number.isNaN(birth.getTime())) {
                         const today = new Date();
-                        let age = today.getFullYear() - birth.getFullYear();
-                        const hasHadBirthdayThisYear =
-                            today.getMonth() > birth.getMonth() ||
-                            (today.getMonth() === birth.getMonth() && today.getDate() >= birth.getDate());
-                        if (!hasHadBirthdayThisYear) age -= 1;
-                        if (Number.isFinite(age) && age > 0 && age < 80) {
-                            return String(age);
+                        const diffMs = today.getTime() - birth.getTime();
+                        const ageYears = diffMs / (1000 * 60 * 60 * 24 * 365.2425);
+                        if (Number.isFinite(ageYears) && ageYears > 0 && ageYears < 80) {
+                            return ageYears.toFixed(1);
                         }
                     }
                 }

--- a/DHP2_DeployDraft1.9D/styles/styles.css
+++ b/DHP2_DeployDraft1.9D/styles/styles.css
@@ -3171,10 +3171,12 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
       width: 100%;
       display: flex;
       justify-content: center;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       column-gap: 0.5rem;
-      row-gap: 0.25rem;
-      white-space: normal;
+      row-gap: 0;
+      white-space: nowrap;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
       margin-bottom:2px;
     }
     .player-vitals--compare {
@@ -3209,7 +3211,7 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     }
 
     .player-vitals--compare .player-vitals__item {
-      flex: 0 1 auto;
+      flex: 0 0 auto;
     }
 
     .player-vitals--compare .player-vitals__value {
@@ -3229,6 +3231,8 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
       justify-content: center;
       gap: 1rem;
       flex-wrap: nowrap;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
     }
     
     /* · · Summary Chips · · */
@@ -3647,10 +3651,12 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
         display: flex;
         justify-content: space-around;
         gap: 0.75rem;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         padding: 0.35rem 0;
         border-top: 1px solid var(--color-panel-border);
         border-bottom: 1px solid var(--color-panel-border);
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
     }
     
     /* · · Table Header · · */
@@ -4006,8 +4012,8 @@ Specificity: (0,2,1);
     }
 
     #player-comparison-modal .summary-chips-container {
-        flex-grow: 1;
-        flex-basis: 150px; /* Allow 2 chips per row on most phones */
+        flex: 0 0 auto;
+        min-width: 150px;
     }
 
 


### PR DESCRIPTION
## Summary
- add rank metadata and conditional coloring to the TTL Team Value analyzer chip and improve chart tooltip dismissal on tap
- reuse decimal-age data for modal vitals chips with numeric fallbacks
- prevent vitals and summary chips from wrapping on mobile by enabling horizontal scrolling when space is limited

## Testing
- Not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d888ea7284832e9b16ec9dde9be978