### PR TITLE
Add TTL value ranking and improve analyzer interactions

### DIFF
--- a/DHP2_DeployDraft1.9D/scripts/analyzer.js
+++ b/DHP2_DeployDraft1.9D/scripts/analyzer.js
@@ -1015,6 +1015,11 @@
         (team) => team.isUserTeam,
       );
 
+      const totalValueRank = computeRank(
+        [...teams].sort((a, b) => b.totalValue - a.totalValue),
+        (team) => team.isUserTeam,
+      );
+
       const fptsRank = computeRank(
         [...teams].sort((a, b) => b.totalFpts - a.totalFpts),
         (team) => team.isUserTeam,
@@ -1051,7 +1056,8 @@
         {
           label: 'TTL Team Value',
           value: formatNumber(userTeam.totalValue),
-          meta: 'KTC',
+          meta: totalValueRank ? `KTC • Rank ${totalValueRank}/${totalTeams}` : 'KTC',
+          accent: totalValueRank ? getRankColor(totalValueRank, totalTeams) : undefined,
         },
         {
           label: 'Starter Value',
@@ -1093,10 +1099,19 @@
       elements.summaryStats.classList.remove('hidden');
     }
 
+    function destroyChartInstance(chart) {
+      if (!chart) return;
+      if (typeof chart.$cleanupTooltip === 'function') {
+        chart.$cleanupTooltip();
+      }
+      delete chart.$cleanupTooltip;
+      chart.destroy();
+    }
+
     function renderLineupChart(teams) {
       state.lineupData = buildLineupDatasets(teams);
       if (state.charts.lineup) {
-        state.charts.lineup.destroy();
+        destroyChartInstance(state.charts.lineup);
       }
       const metricConfig = state.lineupData[state.currentLineupMetric];
       state.charts.lineup = createStackedBarChart(
@@ -1290,17 +1305,68 @@
       return [hexToRgba(hex, 0.8), hexToRgba(hex, 0.32)];
     }
 
+    function clearChartTooltip(chart) {
+      if (!chart) return;
+      if (typeof chart.setActiveElements === 'function') {
+        chart.setActiveElements([]);
+      }
+      if (chart.tooltip?.setActiveElements) {
+        chart.tooltip.setActiveElements([], { x: 0, y: 0 });
+      }
+    }
+
+    function attachTooltipDismissal(chart) {
+      if (!chart?.canvas) return;
+      const { canvas } = chart;
+
+      const clear = () => {
+        clearChartTooltip(chart);
+        if (typeof chart.update === 'function') {
+          chart.update('none');
+        }
+      };
+
+      const handleCanvasPointerDown = (event) => {
+        const elements = chart.getElementsAtEventForMode(
+          event,
+          'nearest',
+          { intersect: true },
+          true,
+        );
+        if (!elements.length) {
+          clear();
+        }
+      };
+
+      const handleDocumentPointerDown = (event) => {
+        if (canvas.contains(event.target)) return;
+        clear();
+      };
+
+      canvas.addEventListener('pointerdown', handleCanvasPointerDown);
+      document.addEventListener('pointerdown', handleDocumentPointerDown);
+
+      chart.$cleanupTooltip = () => {
+        canvas.removeEventListener('pointerdown', handleCanvasPointerDown);
+        document.removeEventListener('pointerdown', handleDocumentPointerDown);
+      };
+    }
+
     function createStackedBarChart(canvas, labels, datasets, options) {
-      return new Chart(canvas, {
+      const chart = new Chart(canvas, {
         type: 'bar',
         data: { labels, datasets },
         options,
       });
+
+      attachTooltipDismissal(chart);
+
+      return chart;
     }
 
     function renderOverallChart(teams) {
       if (state.charts.overall) {
-        state.charts.overall.destroy();
+        destroyChartInstance(state.charts.overall);
       }
 
       const labels = teams.map((team) => truncateLabel(team.teamName));

--- a/DHP2_DeployDraft1.9D/scripts/app.js
+++ b/DHP2_DeployDraft1.9D/scripts/app.js
@@ -3427,11 +3427,23 @@ const wrTeStatOrder = [
             const playerData = state.players?.[playerId];
             if (!playerData) return fallback;
 
+            const valuationData = state.isSuperflex
+                ? state.sflxData?.[playerId]
+                : state.oneQbData?.[playerId];
+
             const collect = (...values) => values
                 .map(value => (typeof value === 'string' ? value.trim() : value))
                 .filter(value => value !== undefined && value !== null && value !== '');
 
             const parseAge = () => {
+                const sheetAge = valuationData?.age;
+                if (sheetAge !== undefined && sheetAge !== null && sheetAge !== '') {
+                    const numeric = Number(sheetAge);
+                    if (Number.isFinite(numeric) && numeric > 0) {
+                        return numeric.toFixed(1);
+                    }
+                }
+
                 const candidates = collect(
                     playerData.age,
                     playerData.metadata?.age,
@@ -3439,9 +3451,9 @@ const wrTeStatOrder = [
                 );
 
                 for (const candidate of candidates) {
-                    const numeric = Number.parseInt(candidate, 10);
+                    const numeric = Number(candidate);
                     if (Number.isFinite(numeric) && numeric > 0) {
-                        return String(numeric);
+                        return numeric.toFixed(1);
                     }
                 }
 
@@ -3449,13 +3461,10 @@ const wrTeStatOrder = [
                     const birth = new Date(playerData.birthdate);
                     if (!Number.isNaN(birth.getTime())) {
                         const today = new Date();
-                        let age = today.getFullYear() - birth.getFullYear();
-                        const hasHadBirthdayThisYear =
-                            today.getMonth() > birth.getMonth() ||
-                            (today.getMonth() === birth.getMonth() && today.getDate() >= birth.getDate());
-                        if (!hasHadBirthdayThisYear) age -= 1;
-                        if (Number.isFinite(age) && age > 0 && age < 80) {
-                            return String(age);
+                        const diffMs = today.getTime() - birth.getTime();
+                        const years = diffMs / (365.2425 * 24 * 60 * 60 * 1000);
+                        if (Number.isFinite(years) && years > 0 && years < 80) {
+                            return years.toFixed(1);
                         }
                     }
                 }

--- a/DHP2_DeployDraft1.9D/styles/styles.css
+++ b/DHP2_DeployDraft1.9D/styles/styles.css
@@ -3652,6 +3652,33 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
         border-top: 1px solid var(--color-panel-border);
         border-bottom: 1px solid var(--color-panel-border);
     }
+
+    @media (max-width: 640px) {
+      .player-vitals--modal,
+      .player-vitals--compare {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        justify-content: flex-start;
+      }
+
+      .player-vitals--compare {
+        column-gap: 0.65rem;
+      }
+
+      .player-vitals--compare .player-vitals__item {
+        flex: 0 0 auto;
+      }
+
+      .comparison-summary-chips-row {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        justify-content: flex-start;
+      }
+
+      .comparison-summary-chips-row .summary-chip {
+        flex: 0 0 auto;
+      }
+    }
     
     /* · · Table Header · · */
     .player-header h4 {


### PR DESCRIPTION
## Summary
- add total team value ranking metadata and accent coloring to the analyzer summary chip
- ensure analyzer bar chart tooltips dismiss immediately on taps by wiring dedicated listeners
- surface decimal ages in modal vitals chips and prevent vitals/summary chips from wrapping on mobile

## Testing
- not run (static site with no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d888ea7284832e9b16ec9dde9be978