### PR TITLE
Exclude low-GP players from PPG summary rankings

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -910,8 +910,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             }
 
             const entries = Object.values(playersById);
+            const MIN_GAMES_FOR_PPG_RANK = 2;
             entries.forEach(entry => {
                 entry.ppg = entry.gamesPlayed > 0 ? entry.totalPts / entry.gamesPlayed : 0;
+                entry.ppgOverallRank = null;
+                entry.ppgPosRank = null;
             });
 
             const totalSorted = entries.slice().sort((a, b) => b.totalPts - a.totalPts);
@@ -930,15 +933,20 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 group.slice().sort((a, b) => b.totalPts - a.totalPts).forEach((entry, index) => {
                     entry.posRank = index + 1;
                 });
-                group.slice().sort((a, b) => b.ppg - a.ppg).forEach((entry, index) => {
-                    entry.ppgPosRank = index + 1;
-                });
+                group
+                    .filter(entry => entry.gamesPlayed >= MIN_GAMES_FOR_PPG_RANK)
+                    .sort((a, b) => b.ppg - a.ppg)
+                    .forEach((entry, index) => {
+                        entry.ppgPosRank = index + 1;
+                    });
             });
 
-            const ppgSorted = entries.slice().sort((a, b) => b.ppg - a.ppg);
-            ppgSorted.forEach((entry, index) => {
-                entry.ppgOverallRank = index + 1;
-            });
+            entries
+                .filter(entry => entry.gamesPlayed >= MIN_GAMES_FOR_PPG_RANK)
+                .sort((a, b) => b.ppg - a.ppg)
+                .forEach((entry, index) => {
+                    entry.ppgOverallRank = index + 1;
+                });
 
             const cache = {};
             entries.forEach(entry => {


### PR DESCRIPTION
## Summary
- ignore players with one or fewer games played when calculating PPG position and overall ranks
- ensure summary chips in the compare and game log modals only show PPG ranks for players with a meaningful sample size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da62f7134c832e9c2d0f82a4409c24