### PR TITLE
Display Sleeper records on roster headers with sticky fade effect

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -36,6 +36,33 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const analyzerButtonContainer = analyzerButtonSlot?.querySelector('.analyzer-button-container') || null;
         const researchButtonContainer = researchButtonSlot?.querySelector('.research-button-container') || null;
 
+        const observedHeaderSentinels = new Set();
+        const headerStickyObserver = (typeof window !== 'undefined' && 'IntersectionObserver' in window)
+            ? new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    const header = entry.target.nextElementSibling;
+                    if (!header || !header.classList?.contains('team-header-item')) return;
+                    if (entry.isIntersecting) {
+                        header.classList.remove('is-stuck');
+                    } else {
+                        header.classList.add('is-stuck');
+                    }
+                });
+            }, { threshold: [0, 1], rootMargin: '-1px 0px 0px 0px' })
+            : null;
+
+        function resetHeaderStickinessObserver() {
+            if (!headerStickyObserver) return;
+            observedHeaderSentinels.forEach((sentinel) => headerStickyObserver.unobserve(sentinel));
+            observedHeaderSentinels.clear();
+        }
+
+        function observeHeaderStickiness(sentinel) {
+            if (!headerStickyObserver || !sentinel) return;
+            headerStickyObserver.observe(sentinel);
+            observedHeaderSentinels.add(sentinel);
+        }
+
         const gameLogsModal = document.getElementById('game-logs-modal');
         const modalCloseBtn = document.querySelector('.modal-close-btn');
         const modalInfoBtn = document.querySelector('.modal-info-btn');
@@ -1632,7 +1659,21 @@ const SEASON_META_HEADERS = {
             const teams = rosters.map(roster => {
                 const owner = userMap[roster.owner_id];
                 const allPlayers = roster.players || [];
-                
+                const settings = roster.settings || {};
+                const parseRecordValue = (value) => {
+                    if (typeof value === 'number') return value;
+                    const parsed = Number(value);
+                    return Number.isFinite(parsed) ? parsed : null;
+                };
+
+                const wins = parseRecordValue(settings.wins);
+                const losses = parseRecordValue(settings.losses);
+                const ties = parseRecordValue(settings.ties);
+                const hasRecord = Number.isFinite(wins) && Number.isFinite(losses);
+                const record = hasRecord
+                    ? `${wins}-${losses}${Number.isFinite(ties) && ties > 0 ? `-${ties}` : ''}`
+                    : null;
+
                 const starterIds = roster.starters || [];
                 const starters = starterIds.map((playerId, index) => {
                     const slot = rosterPositions[index] || 'FLEX';
@@ -1653,6 +1694,7 @@ const SEASON_META_HEADERS = {
                 return {
                     isUserTeam,
                     teamName: owner?.display_name || `Team ${roster.roster_id}`,
+                    record,
                     starters,
                     bench: bench.map(p => getPlayerData(p, 'BN')).sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                     taxi,
@@ -2959,6 +3001,7 @@ const wrTeStatOrder = [
         function renderAllTeamData(teams) {
             rosterGrid.innerHTML = '';
             rosterGrid.style.justifyContent = ''; // Reset style
+            resetHeaderStickinessObserver();
 
             let teamsToRender = teams;
             if (state.isCompareMode) {
@@ -2970,6 +3013,9 @@ const wrTeStatOrder = [
                 const columnWrapper = document.createElement('div');
                 columnWrapper.className = 'roster-column';
                 columnWrapper.dataset.teamName = team.teamName;
+
+                const sentinel = document.createElement('div');
+                sentinel.className = 'team-header-sentinel';
 
                 const header = document.createElement('div');
                 header.className = 'team-header-item';
@@ -2984,17 +3030,25 @@ const wrTeStatOrder = [
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
-                header.title = team.teamName;
+                header.title = team.record ? `${team.teamName} (${team.record})` : team.teamName;
 
 
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
+                if (team.record) {
+                    const recordSpan = document.createElement('span');
+                    recordSpan.className = 'team-record';
+                    recordSpan.textContent = `(${team.record})`;
+                    header.appendChild(recordSpan);
+                }
 
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
 
+                columnWrapper.appendChild(sentinel);
                 columnWrapper.appendChild(header);
                 columnWrapper.appendChild(card);
                 rosterGrid.appendChild(columnWrapper);
+                observeHeaderStickiness(sentinel);
             });
 
             if (compareSearchInput && compareSearchInput.value) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -838,6 +838,7 @@
             display: flex;
             flex-direction: column;
             gap: 0.3rem;
+            position: relative;
             border: 1px solid transparent;       /* new base border */
             border-radius: 8px;                   /* match header */
         }
@@ -852,13 +853,17 @@
       align-items: center;
       justify-content: center;
       gap: 0.5rem;
-      font-size: 0.75rem;
+      font-size: 0.7rem;
       font-weight: 500;
       color: #d0d1ee;
       text-align: center;
       padding: 0.4rem 0.5rem;
       cursor: pointer;
-    
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      transition: opacity 0.2s ease;
+
       /* · · Glass look to match filter groups · · */
       background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
       border: 1px solid var(--color-panel-border);
@@ -866,6 +871,10 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+}
+
+.team-header-item.is-stuck {
+    opacity: 0.65;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;
@@ -2681,7 +2690,22 @@ border: 1px solid rgb(169 178 227 / 9%);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 90px;
+    max-width: 65px;
+}
+
+.team-header-item .team-record {
+    font-size: 0.6rem;
+    color: rgba(208, 209, 238, 0.85);
+    white-space: nowrap;
+}
+
+.team-header-sentinel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    pointer-events: none;
 }
 
 #analyzeLeagueButton {


### PR DESCRIPTION
## Summary
- derive each roster's current record from Sleeper data and persist it with the team object
- render the record beside the team name and adjust header styling to fit the new text
- keep roster headers sticky while scrolling and fade them when pinned for context

## Testing
- curl -si -H "User-Agent: Mozilla/5.0" https://api.sleeper.app/v1/user/the_oracle | head *(fails with 403 in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db245119e4832eba00707a56a5fe99