### PR TITLE
Display Sleeper records on roster headers with sticky fade effect

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -16,6 +16,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const playerListView = document.getElementById('playerListView');
         const rosterContainer = document.getElementById('rosterContainer');
         const rosterGrid = document.getElementById('rosterGrid');
+        const headerContainer = document.getElementById('header-container');
         const compareButton = document.getElementById('compareButton');
         const compareSearchToggle  = document.getElementById('compareSearchToggle');
         const compareSearchPopover = document.getElementById('compareSearchPopover');
@@ -35,6 +36,82 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const researchButtonSlot = document.getElementById('research-button-slot');
         const analyzerButtonContainer = analyzerButtonSlot?.querySelector('.analyzer-button-container') || null;
         const researchButtonContainer = researchButtonSlot?.querySelector('.research-button-container') || null;
+
+        const observedHeaderSentinels = new Set();
+        let headerStickyObserver = null;
+        let headerOffsetUpdateFrame = null;
+
+        const handleHeaderStickinessEntries = (entries) => {
+            entries.forEach((entry) => {
+                const header = entry.target.nextElementSibling;
+                if (!header || !header.classList?.contains('team-header-item')) return;
+                if (entry.isIntersecting) {
+                    header.classList.remove('is-stuck');
+                } else {
+                    header.classList.add('is-stuck');
+                }
+            });
+        };
+
+        function createHeaderStickyObserver(offset) {
+            if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+                headerStickyObserver = null;
+                return;
+            }
+
+            if (headerStickyObserver) {
+                headerStickyObserver.disconnect();
+            }
+
+            headerStickyObserver = new IntersectionObserver(handleHeaderStickinessEntries, {
+                threshold: [0, 1],
+                rootMargin: `${-(offset + 1)}px 0px 0px 0px`,
+            });
+
+            observedHeaderSentinels.forEach((sentinel) => headerStickyObserver.observe(sentinel));
+        }
+
+        function updateTeamHeaderStickyOffset() {
+            if (pageType !== 'rosters' || !headerContainer) return;
+
+            const offset = Math.max(0, Math.round(headerContainer.offsetHeight + 8));
+            document.documentElement.style.setProperty('--team-header-offset', `${offset}px`);
+            createHeaderStickyObserver(offset);
+        }
+
+        function scheduleTeamHeaderOffsetUpdate() {
+            if (typeof window === 'undefined' || pageType !== 'rosters') return;
+            if (headerOffsetUpdateFrame !== null) return;
+
+            headerOffsetUpdateFrame = window.requestAnimationFrame(() => {
+                headerOffsetUpdateFrame = null;
+                updateTeamHeaderStickyOffset();
+            });
+        }
+
+        function resetHeaderStickinessObserver() {
+            if (!headerStickyObserver) {
+                observedHeaderSentinels.clear();
+                return;
+            }
+            observedHeaderSentinels.forEach((sentinel) => headerStickyObserver.unobserve(sentinel));
+            observedHeaderSentinels.clear();
+        }
+
+        function observeHeaderStickiness(sentinel) {
+            if (!sentinel) return;
+            observedHeaderSentinels.add(sentinel);
+            if (headerStickyObserver) {
+                headerStickyObserver.observe(sentinel);
+            }
+        }
+
+        if (pageType === 'rosters') {
+            scheduleTeamHeaderOffsetUpdate();
+            if (typeof window !== 'undefined') {
+                window.addEventListener('resize', scheduleTeamHeaderOffsetUpdate);
+            }
+        }
 
         const gameLogsModal = document.getElementById('game-logs-modal');
         const modalCloseBtn = document.querySelector('.modal-close-btn');
@@ -395,6 +472,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('rosters');
                 contextualControls.classList.remove('hidden');
+                scheduleTeamHeaderOffsetUpdate();
                 playerListView.classList.add('hidden');
                 rosterView.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
@@ -433,6 +511,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('ownership');
                 contextualControls.classList.add('hidden');
+                scheduleTeamHeaderOffsetUpdate();
                 rosterView.classList.add('hidden');
                 playerListView.classList.remove('hidden');
 
@@ -1632,7 +1711,21 @@ const SEASON_META_HEADERS = {
             const teams = rosters.map(roster => {
                 const owner = userMap[roster.owner_id];
                 const allPlayers = roster.players || [];
-                
+                const settings = roster.settings || {};
+                const parseRecordValue = (value) => {
+                    if (typeof value === 'number') return value;
+                    const parsed = Number(value);
+                    return Number.isFinite(parsed) ? parsed : null;
+                };
+
+                const wins = parseRecordValue(settings.wins);
+                const losses = parseRecordValue(settings.losses);
+                const ties = parseRecordValue(settings.ties);
+                const hasRecord = Number.isFinite(wins) && Number.isFinite(losses);
+                const record = hasRecord
+                    ? `${wins}-${losses}${Number.isFinite(ties) && ties > 0 ? `-${ties}` : ''}`
+                    : null;
+
                 const starterIds = roster.starters || [];
                 const starters = starterIds.map((playerId, index) => {
                     const slot = rosterPositions[index] || 'FLEX';
@@ -1653,6 +1746,7 @@ const SEASON_META_HEADERS = {
                 return {
                     isUserTeam,
                     teamName: owner?.display_name || `Team ${roster.roster_id}`,
+                    record,
                     starters,
                     bench: bench.map(p => getPlayerData(p, 'BN')).sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                     taxi,
@@ -2959,6 +3053,8 @@ const wrTeStatOrder = [
         function renderAllTeamData(teams) {
             rosterGrid.innerHTML = '';
             rosterGrid.style.justifyContent = ''; // Reset style
+            resetHeaderStickinessObserver();
+            updateTeamHeaderStickyOffset();
 
             let teamsToRender = teams;
             if (state.isCompareMode) {
@@ -2970,6 +3066,9 @@ const wrTeStatOrder = [
                 const columnWrapper = document.createElement('div');
                 columnWrapper.className = 'roster-column';
                 columnWrapper.dataset.teamName = team.teamName;
+
+                const sentinel = document.createElement('div');
+                sentinel.className = 'team-header-sentinel';
 
                 const header = document.createElement('div');
                 header.className = 'team-header-item';
@@ -2984,17 +3083,25 @@ const wrTeStatOrder = [
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
-                header.title = team.teamName;
+                header.title = team.record ? `${team.teamName} (${team.record})` : team.teamName;
 
 
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
+                if (team.record) {
+                    const recordSpan = document.createElement('span');
+                    recordSpan.className = 'team-record';
+                    recordSpan.textContent = `(${team.record})`;
+                    header.appendChild(recordSpan);
+                }
 
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
 
+                columnWrapper.appendChild(sentinel);
                 columnWrapper.appendChild(header);
                 columnWrapper.appendChild(card);
                 rosterGrid.appendChild(columnWrapper);
+                observeHeaderStickiness(sentinel);
             });
 
             if (compareSearchInput && compareSearchInput.value) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -1,6 +1,7 @@
 /* ⬇︎  VARIABLES, THEME, & FOUNDATION  ⬇︎ */
       :root {
         --font-sans: 'Product Sans', 'Google Sans', 'Quicksand', sans-serif;
+        --team-header-offset: 0px;
     
         /* · · New Color Palette · · */
         --color-bg: #0D0E1B;
@@ -838,6 +839,7 @@
             display: flex;
             flex-direction: column;
             gap: 0.3rem;
+            position: relative;
             border: 1px solid transparent;       /* new base border */
             border-radius: 8px;                   /* match header */
         }
@@ -852,13 +854,17 @@
       align-items: center;
       justify-content: center;
       gap: 0.5rem;
-      font-size: 0.75rem;
+      font-size: 0.7rem;
       font-weight: 500;
       color: #d0d1ee;
       text-align: center;
       padding: 0.4rem 0.5rem;
       cursor: pointer;
-    
+      position: sticky;
+      top: var(--team-header-offset, 0px);
+      z-index: 2;
+      transition: opacity 0.2s ease;
+
       /* · · Glass look to match filter groups · · */
       background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
       border: 1px solid var(--color-panel-border);
@@ -866,6 +872,10 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+}
+
+.team-header-item.is-stuck {
+    opacity: 0.65;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;
@@ -2681,7 +2691,22 @@ border: 1px solid rgb(169 178 227 / 9%);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 90px;
+    max-width: 65px;
+}
+
+.team-header-item .team-record {
+    font-size: 0.6rem;
+    color: rgba(208, 209, 238, 0.85);
+    white-space: nowrap;
+}
+
+.team-header-sentinel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    pointer-events: none;
 }
 
 #analyzeLeagueButton {


### PR DESCRIPTION
## Summary
- derive each roster's current record from Sleeper data and persist it with the team object
- render the record beside the team name and adjust header styling to fit the new text
- keep roster headers sticky beneath the page header, fading them when pinned for context

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db245119e4832eba00707a56a5fe99