### PR TITLE
Show team records and sticky headers on roster columns

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -1624,6 +1624,30 @@ const SEASON_META_HEADERS = {
             return num;
         }
 
+        function formatTeamRecord(settings) {
+            if (!settings || typeof settings !== 'object') {
+                return '0-0';
+            }
+
+            const parseValue = (value) => {
+                if (typeof value === 'number' && Number.isFinite(value)) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const parsed = Number(value);
+                    return Number.isFinite(parsed) ? parsed : 0;
+                }
+                return 0;
+            };
+
+            const wins = parseValue(settings.wins);
+            const losses = parseValue(settings.losses);
+            const ties = parseValue(settings.ties);
+
+            const baseRecord = `${wins}-${losses}`;
+            return ties > 0 ? `${baseRecord}-${ties}` : baseRecord;
+        }
+
         function processRosterData(rosters, users, tradedPicks, leagueInfo) {
             const userMap = users.reduce((acc, user) => ({ ...acc, [user.user_id]: user }), {});
             const rosterPositions = leagueInfo.roster_positions;
@@ -1653,6 +1677,7 @@ const SEASON_META_HEADERS = {
                 return {
                     isUserTeam,
                     teamName: owner?.display_name || `Team ${roster.roster_id}`,
+                    recordDisplay: formatTeamRecord(roster.settings || {}),
                     starters,
                     bench: bench.map(p => getPlayerData(p, 'BN')).sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                     taxi,
@@ -2956,6 +2981,67 @@ const wrTeStatOrder = [
             leagueSelect.disabled = false;
         }
 
+        let teamHeaderScrollHandler = null;
+        let teamHeaderResizeHandler = null;
+        let teamHeaderRafId = null;
+
+        function cleanupTeamHeaderSticky() {
+            if (teamHeaderScrollHandler) {
+                window.removeEventListener('scroll', teamHeaderScrollHandler);
+                teamHeaderScrollHandler = null;
+            }
+            if (teamHeaderResizeHandler) {
+                window.removeEventListener('resize', teamHeaderResizeHandler);
+                teamHeaderResizeHandler = null;
+            }
+            if (teamHeaderRafId !== null) {
+                cancelAnimationFrame(teamHeaderRafId);
+                teamHeaderRafId = null;
+            }
+        }
+
+        function initializeTeamHeaderSticky() {
+            const headers = rosterGrid.querySelectorAll('.team-header-item');
+            if (!headers.length) {
+                cleanupTeamHeaderSticky();
+                return;
+            }
+
+            cleanupTeamHeaderSticky();
+
+            const updateOffset = () => {
+                const headerContainer = document.getElementById('header-container');
+                const headerHeight = headerContainer ? headerContainer.offsetHeight : 0;
+                const offset = headerHeight + 8; // breathing room below the global header
+                document.documentElement.style.setProperty('--team-header-sticky-offset', `${offset}px`);
+            };
+
+            updateOffset();
+            teamHeaderResizeHandler = () => updateOffset();
+            window.addEventListener('resize', teamHeaderResizeHandler);
+
+            const evaluate = () => {
+                teamHeaderRafId = null;
+                headers.forEach((header) => {
+                    const topOffset = parseFloat(getComputedStyle(header).top) || 0;
+                    const { top } = header.getBoundingClientRect();
+                    if (top <= topOffset + 0.5) {
+                        header.classList.add('is-stuck');
+                    } else {
+                        header.classList.remove('is-stuck');
+                    }
+                });
+            };
+
+            teamHeaderScrollHandler = () => {
+                if (teamHeaderRafId !== null) return;
+                teamHeaderRafId = requestAnimationFrame(evaluate);
+            };
+
+            window.addEventListener('scroll', teamHeaderScrollHandler, { passive: true });
+            evaluate();
+        }
+
         function renderAllTeamData(teams) {
             rosterGrid.innerHTML = '';
             rosterGrid.style.justifyContent = ''; // Reset style
@@ -2984,11 +3070,23 @@ const wrTeStatOrder = [
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
-                header.title = team.teamName;
 
+                const nameStack = document.createElement('span');
+                nameStack.className = 'team-name-stack';
+                nameStack.appendChild(teamNameSpan);
+
+                if (team.recordDisplay) {
+                    const teamRecordSpan = document.createElement('span');
+                    teamRecordSpan.className = 'team-record';
+                    teamRecordSpan.textContent = `(${team.recordDisplay})`;
+                    nameStack.appendChild(teamRecordSpan);
+                    header.title = `${team.teamName} (${team.recordDisplay})`;
+                } else {
+                    header.title = team.teamName;
+                }
 
                 header.appendChild(checkbox);
-                header.appendChild(teamNameSpan);
+                header.appendChild(nameStack);
 
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
 
@@ -3000,6 +3098,8 @@ const wrTeStatOrder = [
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+
+            initializeTeamHeaderSticky();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -37,6 +37,8 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
+
+        --team-header-sticky-offset: 0px;
     
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
@@ -851,14 +853,18 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 0.5rem;
-      font-size: 0.75rem;
+      gap: 0.4rem;
+      font-size: 0.7rem;
       font-weight: 500;
       color: #d0d1ee;
       text-align: center;
       padding: 0.4rem 0.5rem;
       cursor: pointer;
-    
+      position: sticky;
+      top: var(--team-header-sticky-offset, 0px);
+      z-index: 2;
+      transition: opacity 0.2s ease;
+
       /* · · Glass look to match filter groups · · */
       background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
       border: 1px solid var(--color-panel-border);
@@ -867,6 +873,9 @@
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
 }
+        .team-header-item.is-stuck {
+            opacity: 0.6;
+        }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;
             
@@ -2681,7 +2690,20 @@ border: 1px solid rgb(169 178 227 / 9%);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 90px;
+    max-width: 65px;
+}
+
+.team-header-item .team-name-stack {
+    display: flex;
+    align-items: baseline;
+    gap: 0.2rem;
+    min-width: 0;
+}
+
+.team-header-item .team-record {
+    font-size: 0.6rem;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
 }
 
 #analyzeLeagueButton {


### PR DESCRIPTION
## Summary
- format and store each team's Sleeper record while processing roster data
- render the record beside the roster header name and keep titles sticky with a fade when stuck
- tweak roster header styling for the new record text and sticky offset handling

## Testing
- manual - loaded `rosters/rosters.html?username=the_oracle`


------
https://chatgpt.com/codex/tasks/task_e_68db2427f81c832e9497d07f54690b38