### PR TITLE
Move roster headers below page header

### DIFF
--- a/DHP2_DeployDraft2.11/rosters/rosters.html
+++ b/DHP2_DeployDraft2.11/rosters/rosters.html
@@ -220,9 +220,10 @@
   </div>
 </div>
 <div class="hidden" id="rosterView">
-<div id="rosterContainer">
-<div id="rosterGrid"></div>
-</div>
+  <div id="rosterContainer">
+    <div id="teamHeaderBar" class="team-header-row"></div>
+    <div id="rosterGrid"></div>
+  </div>
 </div>
 <div class="hidden" id="playerListView">
 </div>

--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -16,6 +16,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const playerListView = document.getElementById('playerListView');
         const rosterContainer = document.getElementById('rosterContainer');
         const rosterGrid = document.getElementById('rosterGrid');
+        const teamHeaderBar = document.getElementById('teamHeaderBar');
         const compareButton = document.getElementById('compareButton');
         const compareSearchToggle  = document.getElementById('compareSearchToggle');
         const compareSearchPopover = document.getElementById('compareSearchPopover');
@@ -194,6 +195,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         // --- State ---
         let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false, liveWeeklyStats: {}, liveStatsLoaded: false, currentNflSeason: null, currentNflWeek: null, calculatedRankCache: null };
+        let teamHeaderObserver = null;
+        let teamHeaderSentinelMap = new WeakMap();
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
@@ -275,6 +278,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 if (e && e.target && e.target.blur) e.target.blur();
             });
             rosterGrid?.addEventListener('click', handleTeamSelect);
+            teamHeaderBar?.addEventListener('click', handleTeamSelect);
             mainContent?.addEventListener('click', handleAssetClickForTrade);
 
             tradeSimulator.addEventListener('click', (e) => {
@@ -658,6 +662,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             const query = (q || '').trim().toLowerCase();
             const rosterColumns = rosterGrid.querySelectorAll('.roster-column');
+            const headerItems = teamHeaderBar ? Array.from(teamHeaderBar.querySelectorAll('.team-header-item')) : [];
 
             rosterColumns.forEach(column => {
                 const playerRows = column.querySelectorAll('.player-row');
@@ -684,6 +689,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 });
 
                 column.classList.toggle('compare-search-hidden', Boolean(query) && !hasMatch);
+
+                if (headerItems.length) {
+                    const teamName = column.dataset.teamName;
+                    const header = headerItems.find(item => item.dataset.teamName === teamName);
+                    if (header) {
+                        header.classList.toggle('compare-search-hidden', Boolean(query) && !hasMatch);
+                    }
+                }
             });
         }
 
@@ -1632,7 +1645,7 @@ const SEASON_META_HEADERS = {
             const teams = rosters.map(roster => {
                 const owner = userMap[roster.owner_id];
                 const allPlayers = roster.players || [];
-                
+
                 const starterIds = roster.starters || [];
                 const starters = starterIds.map((playerId, index) => {
                     const slot = rosterPositions[index] || 'FLEX';
@@ -1646,13 +1659,15 @@ const SEASON_META_HEADERS = {
                 const bench = allPlayers.filter(pId => pId && !starterIds.includes(pId) && !(roster.taxi || []).includes(pId));
                 const draftPicks = getOwnedPicks(roster.roster_id, tradedPicks, leagueInfo);
                
-               
-               const isUserTeam = roster.owner_id === state.userId || 
-               (roster.co_owners?.includes(state.userId) ?? false);
+
+                const isUserTeam = roster.owner_id === state.userId ||
+                    (roster.co_owners?.includes(state.userId) ?? false);
+                const record = getTeamRecord(roster);
 
                 return {
                     isUserTeam,
                     teamName: owner?.display_name || `Team ${roster.roster_id}`,
+                    record,
                     starters,
                     bench: bench.map(p => getPlayerData(p, 'BN')).sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                     taxi,
@@ -1669,7 +1684,32 @@ const SEASON_META_HEADERS = {
                 return a.teamName.localeCompare(b.teamName);
             });
         }
-        
+
+        function getTeamRecord(roster) {
+            if (!roster) return null;
+            const settings = roster.settings || {};
+            const parseRecordValue = (value) => {
+                if (value === undefined || value === null) return null;
+                const numericValue = Number(value);
+                return Number.isFinite(numericValue) ? numericValue : null;
+            };
+
+            const wins = parseRecordValue(settings.wins);
+            const losses = parseRecordValue(settings.losses);
+            const ties = parseRecordValue(settings.ties);
+
+            if (wins === null || losses === null) {
+                return null;
+            }
+
+            const recordParts = [`${wins}`, `${losses}`];
+            if (ties !== null && ties > 0) {
+                recordParts.push(`${ties}`);
+            }
+
+            return recordParts.join('-');
+        }
+
         function getOwnedPicks(rosterId, tradedPicks, leagueInfo) {
             const defaultRounds = leagueInfo.settings.draft_rounds || 5;
             const leagueSeason = parseInt(leagueInfo.season);
@@ -2959,11 +2999,19 @@ const wrTeStatOrder = [
         function renderAllTeamData(teams) {
             rosterGrid.innerHTML = '';
             rosterGrid.style.justifyContent = ''; // Reset style
+            if (teamHeaderBar) {
+                teamHeaderBar.innerHTML = '';
+            }
 
             let teamsToRender = teams;
             if (state.isCompareMode) {
                 teamsToRender = teams.filter(team => state.teamsToCompare.has(team.teamName));
                 rosterGrid.style.justifyContent = 'center';
+                if (teamHeaderBar) {
+                    teamHeaderBar.style.justifyContent = 'center';
+                }
+            } else if (teamHeaderBar) {
+                teamHeaderBar.style.justifyContent = '';
             }
 
             teamsToRender.forEach(team => {
@@ -2973,6 +3021,11 @@ const wrTeStatOrder = [
 
                 const header = document.createElement('div');
                 header.className = 'team-header-item';
+                header.dataset.teamName = team.teamName;
+
+                const sentinel = document.createElement('div');
+                sentinel.className = 'team-header-sentinel';
+                header.appendChild(sentinel);
 
                 const checkbox = document.createElement('div');
                 checkbox.className = 'team-compare-checkbox';
@@ -2984,22 +3037,95 @@ const wrTeStatOrder = [
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
-                header.title = team.teamName;
+                header.title = team.record ? `${team.teamName} (${team.record})` : team.teamName;
 
+                let recordSpan = null;
+                if (team.record) {
+                    recordSpan = document.createElement('span');
+                    recordSpan.className = 'team-record';
+                    recordSpan.textContent = `(${team.record})`;
+                }
 
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
+                if (recordSpan) {
+                    header.appendChild(recordSpan);
+                }
 
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
 
-                columnWrapper.appendChild(header);
                 columnWrapper.appendChild(card);
+                if (state.teamsToCompare.has(team.teamName)) {
+                    columnWrapper.classList.add('compare-selected');
+                }
+
                 rosterGrid.appendChild(columnWrapper);
+
+                if (teamHeaderBar) {
+                    teamHeaderBar.appendChild(header);
+                } else {
+                    columnWrapper.insertBefore(header, columnWrapper.firstChild);
+                }
             });
+
+            refreshTeamHeaderObserver();
 
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+        }
+
+        function refreshTeamHeaderObserver() {
+            if (pageType !== 'rosters') return;
+            updateTeamHeaderOffset();
+
+            if (teamHeaderObserver) {
+                teamHeaderObserver.disconnect();
+            }
+
+            const headerContainer = teamHeaderBar || rosterGrid;
+            const headers = headerContainer?.querySelectorAll('.team-header-item') || [];
+            if (!headers.length || typeof IntersectionObserver === 'undefined') {
+                headers.forEach(header => header.classList.remove('is-stuck'));
+                return;
+            }
+
+            teamHeaderSentinelMap = new WeakMap();
+            teamHeaderObserver = new IntersectionObserver(handleTeamHeaderIntersection, { threshold: [0], rootMargin: '0px 0px 0px 0px' });
+
+            headers.forEach(header => {
+                const sentinel = header.querySelector('.team-header-sentinel');
+                if (!sentinel) return;
+                teamHeaderSentinelMap.set(sentinel, header);
+                header.classList.remove('is-stuck');
+                teamHeaderObserver.observe(sentinel);
+            });
+        }
+
+        function handleTeamHeaderIntersection(entries) {
+            entries.forEach(entry => {
+                const header = teamHeaderSentinelMap.get(entry.target);
+                if (!header) return;
+                if (entry.isIntersecting) {
+                    header.classList.remove('is-stuck');
+                } else {
+                    header.classList.add('is-stuck');
+                }
+            });
+        }
+
+        function updateTeamHeaderOffset() {
+            if (pageType !== 'rosters') return;
+            const headerContainer = document.getElementById('header-container');
+            const baseOffset = 8;
+            if (!headerContainer) {
+                document.documentElement.style.setProperty('--team-header-sticky-offset', `${baseOffset}px`);
+                return;
+            }
+
+            const rect = headerContainer.getBoundingClientRect();
+            const offset = Math.ceil(rect.height) + baseOffset;
+            document.documentElement.style.setProperty('--team-header-sticky-offset', `${offset}px`);
         }
 
         function createDepthChartTeamCard(team) {
@@ -3971,6 +4097,11 @@ const wrTeStatOrder = [
             const data = await response.json();
             state.cache[url] = data;
             return data;
+        }
+
+        if (pageType === 'rosters') {
+            window.addEventListener('resize', refreshTeamHeaderObserver);
+            window.addEventListener('load', updateTeamHeaderOffset);
         }
     
 

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -32,12 +32,13 @@
         --pos-sflx: #FF3A75ca;
         --pos-bn: #64748b;
         --pos-tx: #808ea3;
-    
+
         /* · · Other vars · · */
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
-    
+        --team-header-sticky-offset: 0.5rem;
+
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
         --orb3-top: 23rem;
@@ -815,15 +816,26 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
-            width: 100%; 
-            overflow-x: auto; 
+        #rosterContainer {
+            width: 100%;
+            overflow-x: auto;
             padding: 1px;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 0.35rem;
         }
-        #rosterGrid { 
-            display: flex; 
-            flex-direction: row; 
-            flex-wrap: nowrap; 
+        .team-header-row {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            gap: 2px;
+            min-width: min-content;
+        }
+        #rosterGrid {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
             gap: 2px;
             min-width: min-content; 
             padding-bottom: 1rem; /* For scrollbar clearance */
@@ -843,37 +855,77 @@
         }
 
 /* ⬇︎  ENTIRE COLUMN GLOW  ⬇︎ */
-.roster-column:has(.team-compare-checkbox.selected) {
+.roster-column.compare-selected {
     box-shadow: inset 0 0 2px #6300ff55, inset 0 0 38px #5300ff35;          /* same highlight as header */
 }
-		
+
        .team-header-item {
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 0.5rem;
-      font-size: 0.75rem;
-      font-weight: 500;
-      color: #d0d1ee;
+      gap: 0.35rem;
+      font-size: 0.7rem;
+      font-weight: 600;
+      color: var(--color-text-primary);
       text-align: center;
       padding: 0.4rem 0.5rem;
       cursor: pointer;
-    
+      position: sticky;
+      top: var(--team-header-sticky-offset, 0.5rem);
+      z-index: 2;
+      transition: opacity 0.2s ease;
+      flex: 0 0 127px;
+      min-width: 127px;
+
       /* · · Glass look to match filter groups · · */
-      background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
+      background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.12));
       border: 1px solid var(--color-panel-border);
       border-radius: 8px;
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
-      box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.35);
+      text-shadow: 0 0 6px rgba(9, 12, 30, 0.55);
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;
-            
+
         }
-		.team-header-item:has(.team-compare-checkbox.selected) {
+                .team-header-item:has(.team-compare-checkbox.selected) {
           border: 1px solid #6300ffaa;
-		}
+                }
+.team-header-item.is-stuck {
+    opacity: 0.65;
+    box-shadow: inset 0 1px 1px rgba(255,255,255,0.05), 0 6px 12px rgba(0, 0, 0, 0.25);
+}
+
+.team-header-item .team-name {
+    color: inherit;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    max-width: 65px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.team-header-item .team-record {
+    font-size: 0.6rem;
+    color: var(--color-text-secondary);
+    line-height: 1;
+    white-space: nowrap;
+    font-weight: 500;
+    opacity: 0.95;
+}
+
+.team-header-sentinel {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: calc(-1 * var(--team-header-sticky-offset, 0.5rem) - 1px);
+    height: 1px;
+    pointer-events: none;
+    opacity: 0;
+}
         .team-card { 
             display: flex; 
             flex-direction: column; 
@@ -2681,7 +2733,7 @@ border: 1px solid rgb(169 178 227 / 9%);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 90px;
+    max-width: 65px;
 }
 
 #analyzeLeagueButton {


### PR DESCRIPTION
## Summary
- continue displaying each team's Sleeper record beside the roster header while relocating the header row beneath the global page header
- refactor header rendering into a shared top bar so sticky fade, compare toggles, and search filtering stay functional across roster columns
- tweak roster container and header styles to align the new header row, constrain team name width, and preserve the faded sticky behaviour

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68db23a82b30832eb6cba86666c70e37