### PR TITLE
Anchor roster headers beneath the app header

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -1624,6 +1624,30 @@ const SEASON_META_HEADERS = {
             return num;
         }
 
+        function formatTeamRecord(settings) {
+            if (!settings || typeof settings !== 'object') {
+                return '0-0';
+            }
+
+            const parseValue = (value) => {
+                if (typeof value === 'number' && Number.isFinite(value)) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const parsed = Number(value);
+                    return Number.isFinite(parsed) ? parsed : 0;
+                }
+                return 0;
+            };
+
+            const wins = parseValue(settings.wins);
+            const losses = parseValue(settings.losses);
+            const ties = parseValue(settings.ties);
+
+            const baseRecord = `${wins}-${losses}`;
+            return ties > 0 ? `${baseRecord}-${ties}` : baseRecord;
+        }
+
         function processRosterData(rosters, users, tradedPicks, leagueInfo) {
             const userMap = users.reduce((acc, user) => ({ ...acc, [user.user_id]: user }), {});
             const rosterPositions = leagueInfo.roster_positions;
@@ -1653,6 +1677,7 @@ const SEASON_META_HEADERS = {
                 return {
                     isUserTeam,
                     teamName: owner?.display_name || `Team ${roster.roster_id}`,
+                    recordDisplay: formatTeamRecord(roster.settings || {}),
                     starters,
                     bench: bench.map(p => getPlayerData(p, 'BN')).sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                     taxi,
@@ -2956,6 +2981,133 @@ const wrTeStatOrder = [
             leagueSelect.disabled = false;
         }
 
+        let teamHeaderScrollHandler = null;
+        let teamHeaderResizeHandler = null;
+        let teamHeaderRafId = null;
+        let teamHeaderResizeObserver = null;
+        let stickyHeaders = [];
+        let stickyOffsetValue = 0;
+        let stickyNeedsOffsetUpdate = false;
+
+        function cleanupTeamHeaderSticky() {
+            if (teamHeaderScrollHandler) {
+                window.removeEventListener('scroll', teamHeaderScrollHandler);
+                document.removeEventListener('scroll', teamHeaderScrollHandler);
+                if (rosterContainer) {
+                    rosterContainer.removeEventListener('scroll', teamHeaderScrollHandler);
+                }
+                teamHeaderScrollHandler = null;
+            }
+            if (teamHeaderResizeHandler) {
+                window.removeEventListener('resize', teamHeaderResizeHandler);
+                teamHeaderResizeHandler = null;
+            }
+            if (teamHeaderRafId !== null) {
+                cancelAnimationFrame(teamHeaderRafId);
+                teamHeaderRafId = null;
+            }
+            if (teamHeaderResizeObserver) {
+                try {
+                    teamHeaderResizeObserver.disconnect();
+                } catch (e) { /* no-op */ }
+                teamHeaderResizeObserver = null;
+            }
+            stickyHeaders.forEach((header) => {
+                header.classList.remove('is-stuck');
+            });
+            stickyHeaders = [];
+            stickyOffsetValue = 0;
+            stickyNeedsOffsetUpdate = false;
+        }
+
+        function initializeTeamHeaderSticky() {
+            const headers = rosterGrid.querySelectorAll('.team-header-item');
+            if (!headers.length) {
+                cleanupTeamHeaderSticky();
+                return;
+            }
+
+            cleanupTeamHeaderSticky();
+
+            stickyHeaders = Array.from(headers);
+            stickyHeaders.forEach(header => {
+                header.classList.remove('is-stuck');
+            });
+
+            const updateOffset = () => {
+                const headerContainer = document.getElementById('header-container');
+                let computedOffset = 0;
+                if (headerContainer) {
+                    const headerRect = headerContainer.getBoundingClientRect();
+                    const headerStyles = window.getComputedStyle(headerContainer);
+                    const marginBottom = parseFloat(headerStyles.marginBottom) || 0;
+                    const baseGap = 1;
+                    computedOffset = Math.max(0, headerRect.bottom + marginBottom + baseGap);
+                }
+                stickyOffsetValue = computedOffset;
+                document.documentElement.style.setProperty('--team-header-sticky-offset', `${computedOffset}px`);
+            };
+
+            const applyStickyState = () => {
+                if (!stickyHeaders.length) {
+                    return;
+                }
+
+                stickyHeaders.forEach((header) => {
+                    const rect = header.getBoundingClientRect();
+                    const headerTop = rect.top;
+                    const headerBottom = rect.bottom;
+                    const stuck = headerTop <= stickyOffsetValue + 0.5 && headerBottom > stickyOffsetValue + 0.5;
+                    if (stuck) {
+                        header.classList.add('is-stuck');
+                    } else {
+                        header.classList.remove('is-stuck');
+                    }
+                });
+            };
+
+            const scheduleStickyUpdate = (shouldUpdateOffset = false) => {
+                if (shouldUpdateOffset) {
+                    stickyNeedsOffsetUpdate = true;
+                }
+                if (teamHeaderRafId !== null) {
+                    return;
+                }
+                teamHeaderRafId = requestAnimationFrame(() => {
+                    teamHeaderRafId = null;
+                    if (stickyNeedsOffsetUpdate) {
+                        updateOffset();
+                        stickyNeedsOffsetUpdate = false;
+                    }
+                    applyStickyState();
+                });
+            };
+
+            updateOffset();
+            applyStickyState();
+
+            teamHeaderResizeHandler = () => {
+                scheduleStickyUpdate(true);
+            };
+            window.addEventListener('resize', teamHeaderResizeHandler);
+
+            teamHeaderScrollHandler = () => scheduleStickyUpdate();
+            window.addEventListener('scroll', teamHeaderScrollHandler, { passive: true });
+            document.addEventListener('scroll', teamHeaderScrollHandler, { passive: true });
+
+            if (rosterContainer) {
+                rosterContainer.addEventListener('scroll', teamHeaderScrollHandler, { passive: true });
+            }
+            if (window.ResizeObserver) {
+                const headerContainer = document.getElementById('header-container');
+                if (headerContainer) {
+                    teamHeaderResizeObserver = new ResizeObserver(() => scheduleStickyUpdate(true));
+                    teamHeaderResizeObserver.observe(headerContainer);
+                }
+            }
+            scheduleStickyUpdate(true);
+        }
+
         function renderAllTeamData(teams) {
             rosterGrid.innerHTML = '';
             rosterGrid.style.justifyContent = ''; // Reset style
@@ -2984,11 +3136,23 @@ const wrTeStatOrder = [
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
-                header.title = team.teamName;
 
+                const nameStack = document.createElement('span');
+                nameStack.className = 'team-name-stack';
+                nameStack.appendChild(teamNameSpan);
+
+                if (team.recordDisplay) {
+                    const teamRecordSpan = document.createElement('span');
+                    teamRecordSpan.className = 'team-record';
+                    teamRecordSpan.textContent = `(${team.recordDisplay})`;
+                    nameStack.appendChild(teamRecordSpan);
+                    header.title = `${team.teamName} (${team.recordDisplay})`;
+                } else {
+                    header.title = team.teamName;
+                }
 
                 header.appendChild(checkbox);
-                header.appendChild(teamNameSpan);
+                header.appendChild(nameStack);
 
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
 
@@ -3000,6 +3164,8 @@ const wrTeStatOrder = [
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+
+            initializeTeamHeaderSticky();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -37,6 +37,8 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
+
+        --team-header-sticky-offset: 0px;
     
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
@@ -837,7 +839,7 @@
             flex-shrink: 0;
             display: flex;
             flex-direction: column;
-            gap: 0.3rem;
+            gap: 0;
             border: 1px solid transparent;       /* new base border */
             border-radius: 8px;                   /* match header */
         }
@@ -851,14 +853,19 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 0.5rem;
-      font-size: 0.75rem;
+      gap: 0.4rem;
+      font-size: 0.7rem;
       font-weight: 500;
       color: #d0d1ee;
       text-align: center;
       padding: 0.4rem 0.5rem;
       cursor: pointer;
-    
+      position: sticky;
+      top: var(--team-header-sticky-offset, 0px);
+      z-index: 9;
+      transition: opacity 0.2s ease;
+      margin-bottom: 0.35rem;
+
       /* · · Glass look to match filter groups · · */
       background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
       border: 1px solid var(--color-panel-border);
@@ -867,9 +874,12 @@
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
 }
+        .team-header-item.is-stuck {
+            opacity: 0.6;
+        }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;
-            
+
         }
 		.team-header-item:has(.team-compare-checkbox.selected) {
           border: 1px solid #6300ffaa;
@@ -2681,8 +2691,22 @@ border: 1px solid rgb(169 178 227 / 9%);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 90px;
+    max-width: 65px;
 }
+
+.team-header-item .team-name-stack {
+    display: flex;
+    align-items: baseline;
+    gap: 0.2rem;
+    min-width: 0;
+}
+
+.team-header-item .team-record {
+    font-size: 0.6rem;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+}
+
 
 #analyzeLeagueButton {
     padding: 0rem 0.6rem;


### PR DESCRIPTION
## Summary
- simplify the roster header sticky handler by removing the placeholder shim and only toggling the fade class
- recalculate the sticky offset from the app header height so frozen headers stay tucked under the toolbar gap
- space the roster cards with header margins so the titles never sit on top of the player tiles

## Testing
- manual - `python3 -m http.server 8000` (rosters page with username `the_oracle`)


------
https://chatgpt.com/codex/tasks/task_e_68db2427f81c832e9497d07f54690b38