### PR TITLE
Keep roster team headers pinned below main header

### DIFF
--- a/DHP2_DeployDraft2.11/rosters/rosters.html
+++ b/DHP2_DeployDraft2.11/rosters/rosters.html
@@ -220,9 +220,11 @@
   </div>
 </div>
 <div class="hidden" id="rosterView">
-<div id="rosterContainer">
-<div id="rosterGrid"></div>
-</div>
+  <div id="rosterContainer">
+    <div id="rosterScroller">
+      <div id="rosterGrid"></div>
+    </div>
+  </div>
 </div>
 <div class="hidden" id="playerListView">
 </div>

--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -27,6 +27,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const clearFiltersButton = document.getElementById('clearFiltersButton');
         const tradeSimulator = document.getElementById('tradeSimulator');
+        const headerContainer = document.getElementById('header-container');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
         const researchButton = document.getElementById('researchButton');
@@ -52,6 +53,102 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         if (compareButton) {
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
+        }
+
+        function updateTeamHeaderOffset() {
+            if (!headerContainer) return;
+            const headerRect = headerContainer.getBoundingClientRect();
+            let marginBottom = 0;
+            try {
+                marginBottom = parseFloat(window.getComputedStyle(headerContainer).marginBottom) || 0;
+            } catch (err) {
+                marginBottom = 0;
+            }
+            const offset = Math.max(0, headerRect.bottom + marginBottom);
+            document.documentElement.style.setProperty('--team-header-offset', `${offset}px`);
+            scheduleStickyTeamHeadersUpdate();
+        }
+
+        function scheduleTeamHeaderOffsetUpdate() {
+            if (pageType !== 'rosters') return;
+            if (typeof requestAnimationFrame === 'function') {
+                requestAnimationFrame(updateTeamHeaderOffset);
+            } else {
+                setTimeout(updateTeamHeaderOffset, 0);
+            }
+        }
+
+        let stickyHeadersAnimationFrame = null;
+
+        function updateStickyTeamHeaders() {
+            stickyHeadersAnimationFrame = null;
+            if (pageType !== 'rosters' || !rosterGrid) return;
+
+            let headerOffset = 0;
+            try {
+                headerOffset = parseFloat(window.getComputedStyle(document.documentElement).getPropertyValue('--team-header-offset')) || 0;
+            } catch (err) {
+                headerOffset = 0;
+            }
+
+            const columns = rosterGrid.querySelectorAll('.roster-column');
+            columns.forEach(column => {
+                const header = column.querySelector('.team-header-item');
+                if (!header) return;
+
+                const headerHeight = header.offsetHeight || header.getBoundingClientRect().height || 0;
+                const columnRect = column.getBoundingClientRect();
+                const columnTop = columnRect.top;
+                const columnBottom = columnRect.bottom;
+                const columnHeight = columnRect.height;
+                let translate = 0;
+
+                if (columnTop < headerOffset) {
+                    const maxTranslate = Math.max(0, columnHeight - headerHeight);
+                    if (columnBottom - headerHeight <= headerOffset) {
+                        translate = maxTranslate;
+                    } else {
+                        translate = Math.min(headerOffset - columnTop, maxTranslate);
+                    }
+                }
+
+                header.style.setProperty('--team-header-translate', `${translate}px`);
+            });
+        }
+
+        function scheduleStickyTeamHeadersUpdate() {
+            if (pageType !== 'rosters') return;
+            if (typeof requestAnimationFrame === 'function') {
+                if (stickyHeadersAnimationFrame !== null) return;
+                stickyHeadersAnimationFrame = requestAnimationFrame(updateStickyTeamHeaders);
+            } else {
+                setTimeout(updateStickyTeamHeaders, 0);
+            }
+        }
+
+        if (pageType === 'rosters') {
+            scheduleTeamHeaderOffsetUpdate();
+            scheduleStickyTeamHeadersUpdate();
+
+            if (headerContainer && 'ResizeObserver' in window) {
+                const headerResizeObserver = new ResizeObserver(() => {
+                    scheduleTeamHeaderOffsetUpdate();
+                    scheduleStickyTeamHeadersUpdate();
+                });
+                headerResizeObserver.observe(headerContainer);
+            }
+
+            window.addEventListener('resize', () => {
+                scheduleTeamHeaderOffsetUpdate();
+                scheduleStickyTeamHeadersUpdate();
+            });
+            window.addEventListener('orientationchange', () => {
+                scheduleTeamHeaderOffsetUpdate();
+                scheduleStickyTeamHeadersUpdate();
+            });
+            window.addEventListener('scroll', scheduleStickyTeamHeadersUpdate, { passive: true });
+            document.addEventListener('scroll', scheduleStickyTeamHeadersUpdate, { passive: true });
+            document.body?.addEventListener('scroll', scheduleStickyTeamHeadersUpdate, { passive: true });
         }
 
         // --- Menu Button ---
@@ -395,6 +492,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('rosters');
                 contextualControls.classList.remove('hidden');
+                scheduleTeamHeaderOffsetUpdate();
+                scheduleStickyTeamHeadersUpdate();
                 playerListView.classList.add('hidden');
                 rosterView.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
@@ -433,6 +532,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('ownership');
                 contextualControls.classList.add('hidden');
+                scheduleTeamHeaderOffsetUpdate();
+                scheduleStickyTeamHeadersUpdate();
                 rosterView.classList.add('hidden');
                 playerListView.classList.remove('hidden');
 
@@ -3000,6 +3101,9 @@ const wrTeStatOrder = [
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+
+            scheduleTeamHeaderOffsetUpdate();
+            scheduleStickyTeamHeadersUpdate();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -37,6 +37,10 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
+
+        /* · · Dynamic layout vars · · */
+        --team-header-offset: 0px;
+        --team-header-translate: 0px;
     
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
@@ -815,10 +819,16 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
-            width: 100%; 
-            overflow-x: auto; 
+        #rosterContainer {
+            width: 100%;
             padding: 1px;
+            overflow: visible;
+        }
+
+        #rosterScroller {
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: visible;
         }
         #rosterGrid { 
             display: flex; 
@@ -866,6 +876,11 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+
+      position: relative;
+      z-index: 3;
+      transform: translateY(var(--team-header-translate, 0px));
+      will-change: transform;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;


### PR DESCRIPTION
## Summary
- wrap the roster grid in a dedicated horizontal scroller so vertical positioning logic is unaffected
- compute and apply dynamic transforms that keep roster team headers locked beneath the page header as the page scrolls
- adjust roster header styling variables to support the new JS-managed sticky behavior

## Testing
- Manual verification of the rosters page using username `the_oracle`

------
https://chatgpt.com/codex/tasks/task_e_68dcaa61c6f8832eae1bf8c4ee8d0b47