### PR TITLE
Stabilize roster headers and auto-scroll trade preview

### DIFF
--- a/DHP2_DeployDraft2.11/rosters/rosters.html
+++ b/DHP2_DeployDraft2.11/rosters/rosters.html
@@ -220,9 +220,11 @@
   </div>
 </div>
 <div class="hidden" id="rosterView">
-<div id="rosterContainer">
-<div id="rosterGrid"></div>
-</div>
+  <div id="rosterContainer">
+    <div id="rosterScroller">
+      <div id="rosterGrid"></div>
+    </div>
+  </div>
 </div>
 <div class="hidden" id="playerListView">
 </div>

--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -27,6 +27,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const clearFiltersButton = document.getElementById('clearFiltersButton');
         const tradeSimulator = document.getElementById('tradeSimulator');
+        const headerContainer = document.getElementById('header-container');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
         const researchButton = document.getElementById('researchButton');
@@ -52,6 +53,62 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         if (compareButton) {
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
+        }
+
+        function updateTeamHeaderOffset() {
+            if (!headerContainer) return;
+            const headerRect = headerContainer.getBoundingClientRect();
+            let marginBottom = 0;
+            try {
+                marginBottom = parseFloat(window.getComputedStyle(headerContainer).marginBottom) || 0;
+            } catch (err) {
+                marginBottom = 0;
+            }
+            const offset = Math.max(0, headerRect.bottom + marginBottom);
+            document.documentElement.style.setProperty('--team-header-offset', `${offset}px`);
+        }
+
+        function scheduleTeamHeaderOffsetUpdate() {
+            if (pageType !== 'rosters') return;
+            if (typeof requestAnimationFrame === 'function') {
+                requestAnimationFrame(updateTeamHeaderOffset);
+            } else {
+                setTimeout(updateTeamHeaderOffset, 0);
+            }
+        }
+
+        const supportsSmoothScroll = 'scrollBehavior' in document.documentElement.style;
+
+        function scrollRosterPageToTop(smooth = true) {
+            if (pageType !== 'rosters') return;
+            if (typeof window.scrollTo === 'function') {
+                if (smooth && supportsSmoothScroll) {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                } else {
+                    window.scrollTo(0, 0);
+                }
+            } else {
+                document.documentElement.scrollTop = 0;
+                document.body.scrollTop = 0;
+            }
+        }
+
+        if (pageType === 'rosters') {
+            scheduleTeamHeaderOffsetUpdate();
+
+            if (headerContainer && 'ResizeObserver' in window) {
+                const headerResizeObserver = new ResizeObserver(() => {
+                    scheduleTeamHeaderOffsetUpdate();
+                });
+                headerResizeObserver.observe(headerContainer);
+            }
+
+            window.addEventListener('resize', () => {
+                scheduleTeamHeaderOffsetUpdate();
+            });
+            window.addEventListener('orientationchange', () => {
+                scheduleTeamHeaderOffsetUpdate();
+            });
         }
 
         // --- Menu Button ---
@@ -395,6 +452,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('rosters');
                 contextualControls.classList.remove('hidden');
+                scheduleTeamHeaderOffsetUpdate();
                 playerListView.classList.add('hidden');
                 rosterView.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
@@ -433,6 +491,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('ownership');
                 contextualControls.classList.add('hidden');
+                scheduleTeamHeaderOffsetUpdate();
                 rosterView.classList.add('hidden');
                 playerListView.classList.remove('hidden');
 
@@ -535,6 +594,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                         renderAllTeamData(state.currentTeams);
                         renderTradeBlock();
                         updateHeaderPreviewState();
+                        scrollRosterPageToTop();
                     }
                 }
                 updateCompareButtonState();
@@ -553,11 +613,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             rosterView.classList.toggle('is-trade-mode', state.isCompareMode);
             rosterGrid.classList.toggle('is-preview-mode', state.isCompareMode);
             updateCompareButtonState();
-            renderAllTeamData(state.currentTeams); 
+            renderAllTeamData(state.currentTeams);
             if (!state.isCompareMode) {
                 clearTrade();
             } else {
                 renderTradeBlock();
+                scrollRosterPageToTop();
             }
             updateHeaderPreviewState();
         }
@@ -3000,6 +3061,8 @@ const wrTeStatOrder = [
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+
+            scheduleTeamHeaderOffsetUpdate();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -37,6 +37,9 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
+
+        /* · · Dynamic layout vars · · */
+        --team-header-offset: 0px;
     
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
@@ -815,10 +818,16 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
-            width: 100%; 
-            overflow-x: auto; 
+        #rosterContainer {
+            width: 100%;
             padding: 1px;
+            overflow: visible;
+        }
+
+        #rosterScroller {
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: visible;
         }
         #rosterGrid { 
             display: flex; 
@@ -866,6 +875,10 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+
+      position: sticky;
+      top: var(--team-header-offset, 0px);
+      z-index: 3;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;


### PR DESCRIPTION
## Summary
- replace the JavaScript transform shim with native sticky roster headers driven by the existing dynamic offset
- trim the unused scroll listeners while keeping the header resize observer so headers stay locked beneath the main header without wobble
- scroll the roster view to the top whenever trade preview mode is triggered from team header selection or the compare toggle

## Testing
- Not run (requires browser verification)


------
https://chatgpt.com/codex/tasks/task_e_68dcaa61c6f8832eae1bf8c4ee8d0b47