### PR TITLE
Restore roster header transform shim

### DIFF
--- a/DHP2_DeployDraft2.11/rosters/rosters.html
+++ b/DHP2_DeployDraft2.11/rosters/rosters.html
@@ -220,9 +220,11 @@
   </div>
 </div>
 <div class="hidden" id="rosterView">
-<div id="rosterContainer">
-<div id="rosterGrid"></div>
-</div>
+  <div id="rosterContainer">
+    <div id="rosterScroller">
+      <div id="rosterGrid"></div>
+    </div>
+  </div>
 </div>
 <div class="hidden" id="playerListView">
 </div>

--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -27,6 +27,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const clearFiltersButton = document.getElementById('clearFiltersButton');
         const tradeSimulator = document.getElementById('tradeSimulator');
+        const headerContainer = document.getElementById('header-container');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
         const researchButton = document.getElementById('researchButton');
@@ -52,6 +53,119 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         if (compareButton) {
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
+        }
+
+        let teamHeaderOffset = 0;
+        let pendingRosterHeaderFrame = null;
+
+        function updateTeamHeaderOffset() {
+            if (!headerContainer) {
+                teamHeaderOffset = 0;
+                document.documentElement.style.setProperty('--team-header-offset', '0px');
+                return;
+            }
+            const headerRect = headerContainer.getBoundingClientRect();
+            let marginBottom = 0;
+            try {
+                marginBottom = parseFloat(window.getComputedStyle(headerContainer).marginBottom) || 0;
+            } catch (err) {
+                marginBottom = 0;
+            }
+            teamHeaderOffset = Math.max(0, headerRect.bottom + marginBottom);
+            document.documentElement.style.setProperty('--team-header-offset', `${teamHeaderOffset}px`);
+        }
+
+        function applyRosterHeaderTransforms() {
+            pendingRosterHeaderFrame = null;
+            if (pageType !== 'rosters' || !rosterGrid) {
+                return;
+            }
+
+            const scrollTop = window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0;
+            const columns = rosterGrid.querySelectorAll('.roster-column');
+
+            columns.forEach(column => {
+                const header = column.querySelector('.team-header-item');
+                if (!header) {
+                    return;
+                }
+
+                const columnRect = column.getBoundingClientRect();
+                const columnTop = columnRect.top + scrollTop;
+                const maxTranslate = Math.max(0, column.offsetHeight - header.offsetHeight);
+                let translate = Math.max(0, (scrollTop + teamHeaderOffset) - columnTop);
+                if (translate > maxTranslate) {
+                    translate = maxTranslate;
+                }
+
+                const rounded = Math.round(translate * 100) / 100;
+                const previous = header.dataset.stickyTranslate || '0';
+                if (previous !== String(rounded)) {
+                    header.style.setProperty('--team-header-translate', `${rounded}px`);
+                    header.dataset.stickyTranslate = String(rounded);
+                }
+            });
+        }
+
+        function scheduleTeamHeaderOffsetUpdate() {
+            if (pageType !== 'rosters') {
+                return;
+            }
+            if (pendingRosterHeaderFrame !== null) {
+                return;
+            }
+
+            const raf = window.requestAnimationFrame || ((cb) => setTimeout(cb, 16));
+            pendingRosterHeaderFrame = raf(() => {
+                applyRosterHeaderTransforms();
+            });
+        }
+
+        const supportsSmoothScroll = 'scrollBehavior' in document.documentElement.style;
+
+        function scrollRosterPageToTop(smooth = true) {
+            if (pageType !== 'rosters') return;
+            if (typeof window.scrollTo === 'function') {
+                if (smooth && supportsSmoothScroll) {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                } else {
+                    window.scrollTo(0, 0);
+                }
+            } else {
+                document.documentElement.scrollTop = 0;
+                document.body.scrollTop = 0;
+            }
+            scheduleTeamHeaderOffsetUpdate();
+        }
+
+        if (pageType === 'rosters') {
+            updateTeamHeaderOffset();
+            scheduleTeamHeaderOffsetUpdate();
+
+            if (headerContainer && 'ResizeObserver' in window) {
+                const headerResizeObserver = new ResizeObserver(() => {
+                    updateTeamHeaderOffset();
+                    scheduleTeamHeaderOffsetUpdate();
+                });
+                headerResizeObserver.observe(headerContainer);
+            }
+
+            window.addEventListener('resize', () => {
+                updateTeamHeaderOffset();
+                scheduleTeamHeaderOffsetUpdate();
+            });
+            window.addEventListener('orientationchange', () => {
+                updateTeamHeaderOffset();
+                scheduleTeamHeaderOffsetUpdate();
+            });
+            const scheduleScrollUpdate = () => {
+                scheduleTeamHeaderOffsetUpdate();
+            };
+            try {
+                window.addEventListener('scroll', scheduleScrollUpdate, { passive: true });
+            } catch (err) {
+                window.addEventListener('scroll', scheduleScrollUpdate);
+            }
         }
 
         // --- Menu Button ---
@@ -395,6 +509,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('rosters');
                 contextualControls.classList.remove('hidden');
+                updateTeamHeaderOffset();
+                scheduleTeamHeaderOffsetUpdate();
                 playerListView.classList.add('hidden');
                 rosterView.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
@@ -433,6 +549,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('ownership');
                 contextualControls.classList.add('hidden');
+                updateTeamHeaderOffset();
+                scheduleTeamHeaderOffsetUpdate();
                 rosterView.classList.add('hidden');
                 playerListView.classList.remove('hidden');
 
@@ -535,6 +653,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                         renderAllTeamData(state.currentTeams);
                         renderTradeBlock();
                         updateHeaderPreviewState();
+                        scrollRosterPageToTop();
                     }
                 }
                 updateCompareButtonState();
@@ -553,11 +672,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             rosterView.classList.toggle('is-trade-mode', state.isCompareMode);
             rosterGrid.classList.toggle('is-preview-mode', state.isCompareMode);
             updateCompareButtonState();
-            renderAllTeamData(state.currentTeams); 
+            renderAllTeamData(state.currentTeams);
             if (!state.isCompareMode) {
                 clearTrade();
             } else {
                 renderTradeBlock();
+                scrollRosterPageToTop();
             }
             updateHeaderPreviewState();
         }
@@ -3000,6 +3120,8 @@ const wrTeStatOrder = [
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+
+            scheduleTeamHeaderOffsetUpdate();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -37,6 +37,9 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
+
+        /* · · Dynamic layout vars · · */
+        --team-header-offset: 0px;
     
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
@@ -815,10 +818,16 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
-            width: 100%; 
-            overflow-x: auto; 
+        #rosterContainer {
+            width: 100%;
             padding: 1px;
+            overflow: visible;
+        }
+
+        #rosterScroller {
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: visible;
         }
         #rosterGrid { 
             display: flex; 
@@ -858,7 +867,7 @@
       text-align: center;
       padding: 0.4rem 0.5rem;
       cursor: pointer;
-    
+
       /* · · Glass look to match filter groups · · */
       background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
       border: 1px solid var(--color-panel-border);
@@ -866,6 +875,11 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+
+      position: relative;
+      transform: translate3d(0, var(--team-header-translate, 0px), 0);
+      will-change: transform;
+      z-index: 3;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;


### PR DESCRIPTION
## Summary
- reinstate the JavaScript transform shim for roster headers and schedule updates with requestAnimationFrame to reduce bobble while keeping them anchored under the main header
- refresh the roster/ownership view toggles to recalculate header offsets before scheduling updates so pinned headers stay aligned during mode switches
- keep the trade preview auto-scroll while updating header styling to rely on the new translate variable instead of sticky positioning

## Testing
- ✅ `python -m http.server 8000` (manual Playwright capture of the rosters page using username the_oracle)


------
https://chatgpt.com/codex/tasks/task_e_68dcaa61c6f8832eae1bf8c4ee8d0b47