### PR TITLE
Reintroduce roster header transform shim to minimize wobble

### DIFF
--- a/DHP2_DeployDraft2.11/rosters/rosters.html
+++ b/DHP2_DeployDraft2.11/rosters/rosters.html
@@ -220,9 +220,11 @@
   </div>
 </div>
 <div class="hidden" id="rosterView">
-<div id="rosterContainer">
-<div id="rosterGrid"></div>
-</div>
+  <div id="rosterContainer">
+    <div id="rosterScroller">
+      <div id="rosterGrid"></div>
+    </div>
+  </div>
 </div>
 <div class="hidden" id="playerListView">
 </div>

--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -27,6 +27,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const clearFiltersButton = document.getElementById('clearFiltersButton');
         const tradeSimulator = document.getElementById('tradeSimulator');
+        const headerContainer = document.getElementById('header-container');
+        const rosterScroller = document.getElementById('rosterScroller');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
         const researchButton = document.getElementById('researchButton');
@@ -52,6 +54,180 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         if (compareButton) {
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
+        }
+
+        const teamHeaderFloatManager = (() => {
+            if (pageType !== 'rosters' || !rosterGrid) {
+                return {
+                    refresh: () => {},
+                    updateOffset: () => {},
+                };
+            }
+
+            let columns = [];
+            let pending = false;
+            let headerOffset = 0;
+            let isBound = false;
+            let lastViewportWidth = window.innerWidth;
+
+            function computeHeaderOffset() {
+                if (!headerContainer) {
+                    return 0;
+                }
+                const rect = headerContainer.getBoundingClientRect();
+                let marginBottom = 0;
+                try {
+                    marginBottom = parseFloat(window.getComputedStyle(headerContainer).marginBottom) || 0;
+                } catch (err) {
+                    marginBottom = 0;
+                }
+                return Math.max(0, rect.bottom + marginBottom);
+            }
+
+            function captureColumns() {
+                columns = [];
+                const rosterColumns = rosterGrid.querySelectorAll('.roster-column');
+                rosterColumns.forEach(column => {
+                    const header = column.querySelector('.team-header-item');
+                    if (!header) {
+                        return;
+                    }
+
+                    header.style.transform = 'translate3d(0, 0, 0)';
+
+                    const columnRect = column.getBoundingClientRect();
+                    const headerRect = header.getBoundingClientRect();
+                    const columnTop = columnRect.top + window.scrollY;
+                    const columnBottom = columnTop + columnRect.height;
+                    const headerTop = headerRect.top + window.scrollY;
+                    const headerHeight = headerRect.height;
+
+                    columns.push({
+                        header,
+                        baseTop: headerTop,
+                        columnBottom,
+                        headerHeight,
+                        lastShift: 0,
+                    });
+
+                    header.style.willChange = 'transform';
+                });
+            }
+
+            function applyTransforms() {
+                pending = false;
+                if (!columns.length) {
+                    return;
+                }
+
+                const scrollTop = window.scrollY;
+                const targetTop = scrollTop + headerOffset;
+
+                columns = columns.filter(entry => document.body.contains(entry.header));
+
+                columns.forEach(entry => {
+                    const availableTravel = (entry.columnBottom - entry.headerHeight) - entry.baseTop;
+                    if (availableTravel <= 0) {
+                        if (entry.lastShift !== 0) {
+                            entry.header.style.transform = 'translate3d(0, 0, 0)';
+                            entry.lastShift = 0;
+                        }
+                        return;
+                    }
+
+                    const maxTop = entry.columnBottom - entry.headerHeight;
+                    const desiredTop = Math.min(maxTop, Math.max(entry.baseTop, targetTop));
+                    const shift = desiredTop - entry.baseTop;
+
+                    if (Math.abs(shift - entry.lastShift) > 0.1) {
+                        const roundedShift = Math.round(shift * 1000) / 1000;
+                        entry.header.style.transform = `translate3d(0, ${roundedShift}px, 0)`;
+                        entry.lastShift = roundedShift;
+                    }
+                });
+            }
+
+            function schedule() {
+                if (pending) {
+                    return;
+                }
+                pending = true;
+                if (typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(applyTransforms);
+                } else {
+                    setTimeout(applyTransforms, 16);
+                }
+            }
+
+            function handleScroll() {
+                if (!columns.length) {
+                    return;
+                }
+                schedule();
+            }
+
+            function handleResize() {
+                const widthChanged = Math.abs(window.innerWidth - lastViewportWidth) > 1;
+                lastViewportWidth = window.innerWidth;
+                headerOffset = computeHeaderOffset();
+                if (widthChanged) {
+                    refresh(true);
+                } else {
+                    schedule();
+                }
+            }
+
+            function bindEvents() {
+                if (isBound) {
+                    return;
+                }
+                isBound = true;
+                window.addEventListener('scroll', handleScroll, { passive: true });
+                window.addEventListener('resize', handleResize);
+                window.addEventListener('orientationchange', handleResize);
+                rosterScroller?.addEventListener('scroll', handleScroll, { passive: true });
+            }
+
+            function refresh(remeasure = true) {
+                bindEvents();
+                headerOffset = computeHeaderOffset();
+                if (remeasure) {
+                    captureColumns();
+                }
+                schedule();
+            }
+
+            return {
+                refresh,
+                updateOffset: () => {
+                    headerOffset = computeHeaderOffset();
+                    schedule();
+                },
+            };
+        })();
+
+        const supportsSmoothScroll = 'scrollBehavior' in document.documentElement.style;
+
+        function scrollRosterPageToTop(smooth = true) {
+            if (pageType !== 'rosters') return;
+            if (typeof window.scrollTo === 'function') {
+                if (smooth && supportsSmoothScroll) {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                } else {
+                    window.scrollTo(0, 0);
+                }
+            } else {
+                document.documentElement.scrollTop = 0;
+                document.body.scrollTop = 0;
+            }
+            teamHeaderFloatManager.refresh(false);
+        }
+
+        if (pageType === 'rosters' && headerContainer && 'ResizeObserver' in window) {
+            const headerResizeObserver = new ResizeObserver(() => {
+                teamHeaderFloatManager.refresh(true);
+            });
+            headerResizeObserver.observe(headerContainer);
         }
 
         // --- Menu Button ---
@@ -395,6 +571,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('rosters');
                 contextualControls.classList.remove('hidden');
+                teamHeaderFloatManager.updateOffset();
                 playerListView.classList.add('hidden');
                 rosterView.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
@@ -433,6 +610,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('ownership');
                 contextualControls.classList.add('hidden');
+                teamHeaderFloatManager.updateOffset();
                 rosterView.classList.add('hidden');
                 playerListView.classList.remove('hidden');
 
@@ -535,6 +713,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                         renderAllTeamData(state.currentTeams);
                         renderTradeBlock();
                         updateHeaderPreviewState();
+                        scrollRosterPageToTop();
                     }
                 }
                 updateCompareButtonState();
@@ -553,11 +732,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             rosterView.classList.toggle('is-trade-mode', state.isCompareMode);
             rosterGrid.classList.toggle('is-preview-mode', state.isCompareMode);
             updateCompareButtonState();
-            renderAllTeamData(state.currentTeams); 
+            renderAllTeamData(state.currentTeams);
             if (!state.isCompareMode) {
                 clearTrade();
             } else {
                 renderTradeBlock();
+                scrollRosterPageToTop();
             }
             updateHeaderPreviewState();
         }
@@ -685,6 +865,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
                 column.classList.toggle('compare-search-hidden', Boolean(query) && !hasMatch);
             });
+
+            teamHeaderFloatManager.refresh(true);
         }
 
         let searchDebounce;
@@ -3000,6 +3182,8 @@ const wrTeStatOrder = [
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+
+            teamHeaderFloatManager.refresh(true);
         }
 
         function createDepthChartTeamCard(team) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -37,7 +37,7 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
-    
+
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
         --orb3-top: 23rem;
@@ -815,10 +815,16 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
-            width: 100%; 
-            overflow-x: auto; 
+        #rosterContainer {
+            width: 100%;
             padding: 1px;
+            overflow: visible;
+        }
+
+        #rosterScroller {
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: visible;
         }
         #rosterGrid { 
             display: flex; 
@@ -866,6 +872,12 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+
+      position: relative;
+      z-index: 3;
+      transform: translate3d(0, 0, 0);
+      will-change: transform;
+      transition: transform 120ms ease-out;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;


### PR DESCRIPTION
## Summary
- restore the JavaScript-managed roster header floater so each header is translated beneath the main app bar instead of using CSS sticky positioning
- add targeted refresh hooks to re-measure columns whenever rosters render, filters change, or the header resizes to keep the headers aligned without covering cards
- update the roster header styling to remove the sticky top variable and smooth the transform-driven motion

## Testing
- Not run (manual roster page verification with username the_oracle required)

------
https://chatgpt.com/codex/tasks/task_e_68dcaa61c6f8832eae1bf8c4ee8d0b47