### PR TITLE
Restore roster header shim with smoother scroll

### DIFF
--- a/DHP2_DeployDraft2.11/rosters/rosters.html
+++ b/DHP2_DeployDraft2.11/rosters/rosters.html
@@ -220,9 +220,11 @@
   </div>
 </div>
 <div class="hidden" id="rosterView">
-<div id="rosterContainer">
-<div id="rosterGrid"></div>
-</div>
+  <div id="rosterContainer">
+    <div id="rosterScroller">
+      <div id="rosterGrid"></div>
+    </div>
+  </div>
 </div>
 <div class="hidden" id="playerListView">
 </div>

--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -27,6 +27,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const clearFiltersButton = document.getElementById('clearFiltersButton');
         const tradeSimulator = document.getElementById('tradeSimulator');
+        const headerContainer = document.getElementById('header-container');
+        const rosterScroller = document.getElementById('rosterScroller');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
         const researchButton = document.getElementById('researchButton');
@@ -52,6 +54,153 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         if (compareButton) {
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
+        }
+
+        const supportsSmoothScroll = 'scrollBehavior' in document.documentElement.style;
+
+        function scrollRosterPageToTop(smooth = true) {
+            if (pageType !== 'rosters') return;
+            if (typeof window.scrollTo === 'function') {
+                if (smooth && supportsSmoothScroll) {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                } else {
+                    window.scrollTo(0, 0);
+                }
+            } else {
+                document.documentElement.scrollTop = 0;
+                document.body.scrollTop = 0;
+            }
+        }
+
+        const rosterHeaderShim = (() => {
+            if (pageType !== 'rosters' || !headerContainer || !rosterGrid) {
+                return null;
+            }
+
+            const entries = [];
+            let rafId = null;
+            let needsMeasure = true;
+
+            const getScrollY = () => window.scrollY ?? document.documentElement.scrollTop ?? document.body.scrollTop ?? 0;
+
+            const measure = () => {
+                entries.length = 0;
+                const headers = rosterGrid.querySelectorAll('.team-header-item');
+                const scrollY = getScrollY();
+
+                headers.forEach(header => {
+                    if (!(header instanceof HTMLElement)) {
+                        return;
+                    }
+
+                    header.style.transform = '';
+                    header.style.willChange = 'transform';
+
+                    const sibling = header.nextElementSibling;
+                    if (sibling instanceof HTMLElement) {
+                        sibling.style.marginTop = '';
+                    }
+
+                    const rect = header.getBoundingClientRect();
+                    entries.push({
+                        header,
+                        column: header.closest('.roster-column'),
+                        sibling: sibling instanceof HTMLElement ? sibling : null,
+                        height: rect.height,
+                        originalTop: rect.top + scrollY,
+                        lastShift: 0
+                    });
+                });
+            };
+
+            const apply = () => {
+                rafId = null;
+                if (needsMeasure) {
+                    measure();
+                    needsMeasure = false;
+                }
+
+                const scrollY = getScrollY();
+                const headerRect = headerContainer.getBoundingClientRect();
+                const headerBottomDocument = headerRect.bottom + scrollY;
+
+                entries.forEach(entry => {
+                    if (!entry.header.isConnected || !entry.column?.isConnected) {
+                        return;
+                    }
+
+                    const columnRect = entry.column.getBoundingClientRect();
+                    const columnBottomDocument = columnRect.bottom + scrollY;
+                    const maxShift = Math.max(0, columnBottomDocument - entry.height - entry.originalTop);
+                    const desiredShift = headerBottomDocument - entry.originalTop;
+                    let shift = Math.min(maxShift, Math.max(0, desiredShift));
+
+                    if (Math.abs(shift - entry.lastShift) < 0.25) {
+                        shift = entry.lastShift;
+                    }
+
+                    if (shift !== entry.lastShift) {
+                        if (shift) {
+                            entry.header.style.transform = `translateY(${shift}px)`;
+                        } else {
+                            entry.header.style.transform = '';
+                        }
+
+                        if (entry.sibling) {
+                            entry.sibling.style.marginTop = shift ? `${shift}px` : '';
+                        }
+
+                        entry.lastShift = shift;
+                    }
+                });
+            };
+
+            const queue = (forceMeasure = false) => {
+                if (forceMeasure) {
+                    needsMeasure = true;
+                }
+
+                if (rafId !== null) {
+                    return;
+                }
+
+                if (typeof requestAnimationFrame === 'function') {
+                    rafId = requestAnimationFrame(apply);
+                } else {
+                    rafId = setTimeout(apply, 16);
+                }
+            };
+
+            return {
+                refresh: () => queue(true),
+                update: () => queue(false)
+            };
+        })();
+
+        const requestRosterHeaderRefresh = () => {
+            if (pageType === 'rosters') {
+                rosterHeaderShim?.refresh();
+            }
+        };
+
+        const requestRosterHeaderUpdate = () => {
+            if (pageType === 'rosters') {
+                rosterHeaderShim?.update();
+            }
+        };
+
+        if (pageType === 'rosters') {
+            rosterHeaderShim?.refresh();
+
+            if (headerContainer && 'ResizeObserver' in window) {
+                const headerResizeObserver = new ResizeObserver(requestRosterHeaderRefresh);
+                headerResizeObserver.observe(headerContainer);
+            }
+
+            window.addEventListener('scroll', requestRosterHeaderUpdate, { passive: true });
+            window.addEventListener('resize', requestRosterHeaderRefresh);
+            window.addEventListener('orientationchange', requestRosterHeaderRefresh);
+            rosterScroller?.addEventListener('scroll', requestRosterHeaderUpdate, { passive: true });
         }
 
         // --- Menu Button ---
@@ -395,6 +544,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('rosters');
                 contextualControls.classList.remove('hidden');
+                requestRosterHeaderRefresh();
                 playerListView.classList.add('hidden');
                 rosterView.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
@@ -433,6 +583,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('ownership');
                 contextualControls.classList.add('hidden');
+                requestRosterHeaderRefresh();
                 rosterView.classList.add('hidden');
                 playerListView.classList.remove('hidden');
 
@@ -535,6 +686,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                         renderAllTeamData(state.currentTeams);
                         renderTradeBlock();
                         updateHeaderPreviewState();
+                        scrollRosterPageToTop();
                     }
                 }
                 updateCompareButtonState();
@@ -553,11 +705,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             rosterView.classList.toggle('is-trade-mode', state.isCompareMode);
             rosterGrid.classList.toggle('is-preview-mode', state.isCompareMode);
             updateCompareButtonState();
-            renderAllTeamData(state.currentTeams); 
+            renderAllTeamData(state.currentTeams);
             if (!state.isCompareMode) {
                 clearTrade();
             } else {
                 renderTradeBlock();
+                scrollRosterPageToTop();
             }
             updateHeaderPreviewState();
         }
@@ -685,6 +838,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
                 column.classList.toggle('compare-search-hidden', Boolean(query) && !hasMatch);
             });
+
+            requestRosterHeaderRefresh();
         }
 
         let searchDebounce;
@@ -3000,6 +3155,8 @@ const wrTeStatOrder = [
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+
+            requestRosterHeaderRefresh();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -37,7 +37,7 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
-    
+
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
         --orb3-top: 23rem;
@@ -815,10 +815,16 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
-            width: 100%; 
-            overflow-x: auto; 
+        #rosterContainer {
+            width: 100%;
             padding: 1px;
+            overflow: visible;
+        }
+
+        #rosterScroller {
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: visible;
         }
         #rosterGrid { 
             display: flex; 
@@ -866,6 +872,7 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+      will-change: transform;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;


### PR DESCRIPTION
## Summary
- reinstate the JavaScript-managed roster header shim to keep team headers pinned beneath the page header without overlapping player cards
- throttle the scroll handler with requestAnimationFrame and mirror the header shift into column spacing to smooth the motion and reduce the prior bobble
- remove the sticky CSS variable and styling while continuing to use the auto-scroll helper when trade preview is opened

## Testing
- Not run (requires browser verification)


------
https://chatgpt.com/codex/tasks/task_e_68dcaa61c6f8832eae1bf8c4ee8d0b47