### PR TITLE
Keep roster headers aligned without overlapping cards

### DIFF
--- a/DHP2_DeployDraft2.11/rosters/rosters.html
+++ b/DHP2_DeployDraft2.11/rosters/rosters.html
@@ -220,9 +220,11 @@
   </div>
 </div>
 <div class="hidden" id="rosterView">
-<div id="rosterContainer">
-<div id="rosterGrid"></div>
-</div>
+  <div id="rosterContainer">
+    <div id="rosterScroller">
+      <div id="rosterGrid"></div>
+    </div>
+  </div>
 </div>
 <div class="hidden" id="playerListView">
 </div>

--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -27,6 +27,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const clearFiltersButton = document.getElementById('clearFiltersButton');
         const tradeSimulator = document.getElementById('tradeSimulator');
+        const headerContainer = document.getElementById('header-container');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
         const researchButton = document.getElementById('researchButton');
@@ -52,6 +53,120 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         if (compareButton) {
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
+        }
+
+        let teamHeaderOffset = 0;
+        let pendingRosterHeaderFrame = null;
+
+        function updateTeamHeaderOffset() {
+            if (!headerContainer) {
+                teamHeaderOffset = 0;
+                document.documentElement.style.setProperty('--team-header-offset', '0px');
+                return;
+            }
+            const headerRect = headerContainer.getBoundingClientRect();
+            let marginBottom = 0;
+            try {
+                marginBottom = parseFloat(window.getComputedStyle(headerContainer).marginBottom) || 0;
+            } catch (err) {
+                marginBottom = 0;
+            }
+            teamHeaderOffset = Math.max(0, headerRect.bottom + marginBottom);
+            document.documentElement.style.setProperty('--team-header-offset', `${teamHeaderOffset}px`);
+        }
+
+        function applyRosterHeaderTransforms() {
+            pendingRosterHeaderFrame = null;
+            if (pageType !== 'rosters' || !rosterGrid) {
+                return;
+            }
+
+            const scrollTop = window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0;
+            const columns = rosterGrid.querySelectorAll('.roster-column');
+
+            columns.forEach(column => {
+                const header = column.querySelector('.team-header-item');
+                const card = column.querySelector('.team-card');
+                if (!header || !card) {
+                    return;
+                }
+
+                const columnRect = column.getBoundingClientRect();
+                const columnTop = columnRect.top + scrollTop;
+                const maxTranslate = Math.max(0, column.offsetHeight - header.offsetHeight);
+                let translate = Math.max(0, (scrollTop + teamHeaderOffset) - columnTop);
+                if (translate > maxTranslate) {
+                    translate = maxTranslate;
+                }
+
+                const rounded = Math.round(translate * 100) / 100;
+                const previous = column.dataset.stickyTranslate || '0';
+                if (previous !== String(rounded)) {
+                    column.style.setProperty('--team-header-translate', `${rounded}px`);
+                    column.dataset.stickyTranslate = String(rounded);
+                }
+            });
+        }
+
+        function scheduleTeamHeaderOffsetUpdate() {
+            if (pageType !== 'rosters') {
+                return;
+            }
+            if (pendingRosterHeaderFrame !== null) {
+                return;
+            }
+
+            const raf = window.requestAnimationFrame || ((cb) => setTimeout(cb, 16));
+            pendingRosterHeaderFrame = raf(() => {
+                applyRosterHeaderTransforms();
+            });
+        }
+
+        const supportsSmoothScroll = 'scrollBehavior' in document.documentElement.style;
+
+        function scrollRosterPageToTop(smooth = true) {
+            if (pageType !== 'rosters') return;
+            if (typeof window.scrollTo === 'function') {
+                if (smooth && supportsSmoothScroll) {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                } else {
+                    window.scrollTo(0, 0);
+                }
+            } else {
+                document.documentElement.scrollTop = 0;
+                document.body.scrollTop = 0;
+            }
+            scheduleTeamHeaderOffsetUpdate();
+        }
+
+        if (pageType === 'rosters') {
+            updateTeamHeaderOffset();
+            scheduleTeamHeaderOffsetUpdate();
+
+            if (headerContainer && 'ResizeObserver' in window) {
+                const headerResizeObserver = new ResizeObserver(() => {
+                    updateTeamHeaderOffset();
+                    scheduleTeamHeaderOffsetUpdate();
+                });
+                headerResizeObserver.observe(headerContainer);
+            }
+
+            window.addEventListener('resize', () => {
+                updateTeamHeaderOffset();
+                scheduleTeamHeaderOffsetUpdate();
+            });
+            window.addEventListener('orientationchange', () => {
+                updateTeamHeaderOffset();
+                scheduleTeamHeaderOffsetUpdate();
+            });
+            const scheduleScrollUpdate = () => {
+                scheduleTeamHeaderOffsetUpdate();
+            };
+            try {
+                window.addEventListener('scroll', scheduleScrollUpdate, { passive: true });
+            } catch (err) {
+                window.addEventListener('scroll', scheduleScrollUpdate);
+            }
         }
 
         // --- Menu Button ---
@@ -395,6 +510,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('rosters');
                 contextualControls.classList.remove('hidden');
+                updateTeamHeaderOffset();
+                scheduleTeamHeaderOffsetUpdate();
                 playerListView.classList.add('hidden');
                 rosterView.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
@@ -433,6 +550,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 
                 updateButtonStates('ownership');
                 contextualControls.classList.add('hidden');
+                updateTeamHeaderOffset();
+                scheduleTeamHeaderOffsetUpdate();
                 rosterView.classList.add('hidden');
                 playerListView.classList.remove('hidden');
 
@@ -535,6 +654,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                         renderAllTeamData(state.currentTeams);
                         renderTradeBlock();
                         updateHeaderPreviewState();
+                        scrollRosterPageToTop();
                     }
                 }
                 updateCompareButtonState();
@@ -553,11 +673,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             rosterView.classList.toggle('is-trade-mode', state.isCompareMode);
             rosterGrid.classList.toggle('is-preview-mode', state.isCompareMode);
             updateCompareButtonState();
-            renderAllTeamData(state.currentTeams); 
+            renderAllTeamData(state.currentTeams);
             if (!state.isCompareMode) {
                 clearTrade();
             } else {
                 renderTradeBlock();
+                scrollRosterPageToTop();
             }
             updateHeaderPreviewState();
         }
@@ -3000,6 +3121,8 @@ const wrTeStatOrder = [
             if (compareSearchInput && compareSearchInput.value) {
                 filterTeamsByQuery(compareSearchInput.value);
             }
+
+            scheduleTeamHeaderOffsetUpdate();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -37,6 +37,9 @@
         --panel-border-radius: 12px;
         --card-border-radius: 8px;
         --glow-strength: 0.6; /* FIXED: give it a value so parsing continues */
+
+        /* · · Dynamic layout vars · · */
+        --team-header-offset: 0px;
     
         /* · · Orb 3 (shared) — using lengths so gradient center = orb center · · */
         --orb3-left: 330px;
@@ -815,10 +818,16 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
-            width: 100%; 
-            overflow-x: auto; 
+        #rosterContainer {
+            width: 100%;
             padding: 1px;
+            overflow: visible;
+        }
+
+        #rosterScroller {
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: visible;
         }
         #rosterGrid { 
             display: flex; 
@@ -840,6 +849,7 @@
             gap: 0.3rem;
             border: 1px solid transparent;       /* new base border */
             border-radius: 8px;                   /* match header */
+            --team-header-translate: 0px;
         }
 
 /* ⬇︎  ENTIRE COLUMN GLOW  ⬇︎ */
@@ -858,7 +868,7 @@
       text-align: center;
       padding: 0.4rem 0.5rem;
       cursor: pointer;
-    
+
       /* · · Glass look to match filter groups · · */
       background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
       border: 1px solid var(--color-panel-border);
@@ -866,6 +876,11 @@
       -webkit-backdrop-filter: blur(4px) saturate(110%);
       backdrop-filter: blur(4px) saturate(110%);
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+
+      position: relative;
+      transform: translate3d(0, var(--team-header-translate, 0px), 0);
+      will-change: transform;
+      z-index: 3;
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;
@@ -874,10 +889,12 @@
 		.team-header-item:has(.team-compare-checkbox.selected) {
           border: 1px solid #6300ffaa;
 		}
-        .team-card { 
-            display: flex; 
-            flex-direction: column; 
+        .team-card {
+            display: flex;
+            flex-direction: column;
             gap: 0.25rem;
+            transform: translate3d(0, var(--team-header-translate, 0px), 0);
+            will-change: transform;
         }
 
         .roster-section h3 {


### PR DESCRIPTION
## Summary
- ensure roster header transforms drive a shared column variable so player cards slide with their header instead of being covered while scrolling
- extend the roster column/card styling to inherit the computed translate offset and keep the header spacing stable under the main page header

## Testing
- ⚠️ Manual browser verification with username the_oracle (not run in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcaa61c6f8832eae1bf8c4ee8d0b47