### PR TITLE
Restore roster column width and relax header truncation

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -1653,6 +1653,7 @@ const SEASON_META_HEADERS = {
                 return {
                     isUserTeam,
                     teamName: owner?.display_name || `Team ${roster.roster_id}`,
+                    record: formatTeamRecord(roster.settings),
                     starters,
                     bench: bench.map(p => getPlayerData(p, 'BN')).sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                     taxi,
@@ -1660,7 +1661,7 @@ const SEASON_META_HEADERS = {
                     allPlayers: allPlayers.map(pId => getPlayerData(pId, ''))
                 };
             });
-            
+
             state.currentTeams = teams;
 
             return teams.sort((a, b) => {
@@ -1668,6 +1669,19 @@ const SEASON_META_HEADERS = {
                 if (b.isUserTeam) return 1;
                 return a.teamName.localeCompare(b.teamName);
             });
+        }
+
+        function formatTeamRecord(settings = {}) {
+            const wins = Number.isFinite(settings?.wins) ? settings.wins : null;
+            const losses = Number.isFinite(settings?.losses) ? settings.losses : null;
+            const ties = Number.isFinite(settings?.ties) ? settings.ties : 0;
+
+            if (wins === null || losses === null) {
+                return null;
+            }
+
+            const baseRecord = `${wins}-${losses}`;
+            return ties ? `${baseRecord}-${ties}` : baseRecord;
         }
         
         function getOwnedPicks(rosterId, tradedPicks, leagueInfo) {
@@ -2984,11 +2998,22 @@ const wrTeStatOrder = [
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
-                header.title = team.teamName;
 
+                if (team.record) {
+                    header.title = `${team.teamName} (${team.record})`;
+                } else {
+                    header.title = team.teamName;
+                }
 
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
+
+                if (team.record) {
+                    const recordSpan = document.createElement('span');
+                    recordSpan.className = 'team-record';
+                    recordSpan.textContent = `(${team.record})`;
+                    header.appendChild(recordSpan);
+                }
 
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
 

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -850,15 +850,15 @@
        .team-header-item {
       display: flex;
       align-items: center;
-      justify-content: center;
-      gap: 0.5rem;
-      font-size: 0.75rem;
+      justify-content: flex-start;
+      gap: 0.25rem;
+      font-size: 0.7rem;
       font-weight: 500;
       color: #d0d1ee;
       text-align: center;
-      padding: 0.4rem 0.5rem;
+      padding: 0.32rem 0.45rem;
       cursor: pointer;
-    
+
       /* · · Glass look to match filter groups · · */
       background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
       border: 1px solid var(--color-panel-border);
@@ -2678,10 +2678,21 @@ border: 1px solid rgb(169 178 227 / 9%);
 }
 
 .team-header-item .team-name {
+    flex: 1 1 auto;
+    max-width: calc(100% - 2.4rem);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 90px;
+    min-width: 0;
+    text-align: left;
+}
+
+.team-header-item .team-record {
+    font-size: 0.58rem;
+    color: #9ea5d8;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-left: 0.1rem;
 }
 
 #analyzeLeagueButton {


### PR DESCRIPTION
## Summary
- restore roster column width so the grid stays its original size while keeping the new header alignment
- loosen the team-name truncation and spacing so names like `the_oracle` display fully alongside the smaller record label

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcb2e16ee0832e92058e31b82390b7