### PR TITLE
Restore horizontal scrolling on roster grid

### DIFF
--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -815,15 +815,19 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
+        #rosterContainer {
             padding: 1px;
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: visible;
+            -webkit-overflow-scrolling: touch;
         }
-        #rosterGrid { 
-            display: flex; 
-            flex-direction: row; 
-            flex-wrap: nowrap; 
+        #rosterGrid {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
             gap: 2px;
-            min-width: min-content; 
+            min-width: max-content;
             padding-bottom: 1rem; /* For scrollbar clearance */
 
         }


### PR DESCRIPTION
## Summary
- allow the roster view container to scroll horizontally without affecting the sticky team headers
- size the roster grid using max-content so columns render at their full width when scrolling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddf411a300832ebb9a887c89d8c9ac