### PR TITLE
Restore roster horizontal scroll without affecting sticky headers

### DIFF
--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -815,8 +815,11 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
+        #rosterContainer {
             padding: 1px;
+            overflow-x: auto;
+            overflow-y: visible;
+            -webkit-overflow-scrolling: touch;
         }
         #rosterGrid { 
             display: flex; 
@@ -2067,8 +2070,8 @@ body { min-height: 100%; }
 
 
   /* · · Ownership: centering + width sanity (mobile-safe) · · */
-html, body { overflow-x: hidden !important; }
-main#content { align-items: stretch !important; }
+body[data-page="ownership"] { overflow-x: hidden !important; }
+body[data-page="ownership"] main#content { align-items: stretch !important; }
 
 #playerListView { 
   width: 100% !important;


### PR DESCRIPTION
## Summary
- allow the roster grid container to scroll horizontally with touch momentum while keeping the sticky header offsets intact
- scope the ownership-specific overflow rule to that page so the roster view retains horizontal scrolling capability

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf411a300832ebb9a887c89d8c9ac