### PR TITLE
Keep roster header visible while scrolling

### DIFF
--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -203,6 +203,8 @@
         #header-container {
             position: sticky;
             top: 0;
+            left: 0;
+            right: 0;
             z-index: 10;
             padding: 0.1rem 0rem 0.4rem 0rem;
             border-radius: var(--panel-border-radius);  /* EDITED: Changed background to be more transparent to see bg */
@@ -2067,7 +2069,8 @@ body { min-height: 100%; }
 
 
   /* · · Ownership: centering + width sanity (mobile-safe) · · */
-html, body { overflow-x: hidden !important; }
+body:not([data-page="rosters"]) { overflow-x: hidden !important; }
+body[data-page="rosters"] { overflow-x: auto !important; }
 main#content { align-items: stretch !important; }
 
 #playerListView { 


### PR DESCRIPTION
## Summary
- pin the roster page header horizontally so it stays visible during sideways scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf4172b08832e8c0f27a0762f6da2