### PR TITLE
Restore horizontal scrolling on rosters

### DIFF
--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -209,6 +209,16 @@
             background: linear-gradient(180deg, rgba(11, 11, 18, 0.2) 10%, transparent 100%);
         }
 
+        body[data-page="rosters"] #header-container {
+            left: 0;
+            right: 0;
+        }
+
+        body[data-page="rosters"] #header-container .app-header {
+            width: 100%;
+            max-width: 100vw;
+        }
+
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */
         .glass-panel {
        background-color: rgba(13, 14, 35, 0.21);
@@ -2067,7 +2077,8 @@ body { min-height: 100%; }
 
 
   /* · · Ownership: centering + width sanity (mobile-safe) · · */
-html, body { overflow-x: hidden !important; }
+body:not([data-page="rosters"]) { overflow-x: hidden !important; }
+body[data-page="rosters"] { overflow-x: auto !important; }
 main#content { align-items: stretch !important; }
 
 #playerListView { 


### PR DESCRIPTION
## Summary
- limit the global overflow lock to non-roster pages so rosters can scroll horizontally
- explicitly allow horizontal scrolling on the rosters layout without disturbing the sticky header placement
- keep the roster header pinned to the viewport so the controls stay visible during horizontal swipes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf4172b08832e8c0f27a0762f6da2