### PR TITLE
Keep roster header visible on horizontal scroll

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -3001,6 +3001,7 @@ const wrTeStatOrder = [
                 filterTeamsByQuery(compareSearchInput.value);
             }
             adjustStickyHeaders();
+            syncRosterHeaderPosition();
         }
 
         function createDepthChartTeamCard(team) {
@@ -3859,8 +3860,34 @@ const wrTeStatOrder = [
             teamHeaders.forEach(header => {
                 header.style.top = `${headerHeight}px`;
             });
+
+            const isRosterPage = document.body?.dataset?.page === 'rosters';
+            if (isRosterPage) {
+                document.documentElement.style.setProperty('--roster-header-height', `${headerHeight}px`);
+            } else {
+                document.documentElement.style.removeProperty('--roster-header-height');
+            }
         }
         window.addEventListener('resize', adjustStickyHeaders);
+
+        function syncRosterHeaderPosition() {
+            const header = document.getElementById('header-container');
+            if (!header) return;
+            const isRosterPage = document.body?.dataset?.page === 'rosters';
+            if (!isRosterPage) {
+                if (header.style.transform) {
+                    header.style.transform = '';
+                }
+                return;
+            }
+            if (header.style.transform) {
+                header.style.transform = '';
+            }
+        }
+
+        window.addEventListener('scroll', syncRosterHeaderPosition, { passive: true });
+        window.addEventListener('resize', syncRosterHeaderPosition);
+        syncRosterHeaderPosition();
 
         function showTemporaryTooltip(element, message) {
             const tooltip = document.createElement('div');

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -49,6 +49,10 @@
         margin: 0;
       }
 
+      :root {
+        --roster-header-height: 0px;
+      }
+
       body {
         font-family: var(--font-sans);
         background-color: #0b0b12;
@@ -207,6 +211,25 @@
             padding: 0.1rem 0rem 0.4rem 0rem;
             border-radius: var(--panel-border-radius);  /* EDITED: Changed background to be more transparent to see bg */
             background: linear-gradient(180deg, rgba(11, 11, 18, 0.2) 10%, transparent 100%);
+        }
+
+        body[data-page="rosters"] #header-container {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            width: 100vw;
+            max-width: none;
+            will-change: auto;
+        }
+
+        body[data-page="rosters"] #header-container .app-header {
+            width: 100%;
+            max-width: none;
+        }
+
+        body[data-page="rosters"] main#content {
+            padding-top: calc(var(--roster-header-height, 0px) + 0.75rem);
         }
 
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */
@@ -2067,7 +2090,8 @@ body { min-height: 100%; }
 
 
   /* · · Ownership: centering + width sanity (mobile-safe) · · */
-html, body { overflow-x: hidden !important; }
+body:not([data-page="rosters"]) { overflow-x: hidden !important; }
+body[data-page="rosters"] { overflow-x: auto !important; }
 main#content { align-items: stretch !important; }
 
 #playerListView { 


### PR DESCRIPTION
## Summary
- pin the roster page header using a fixed position so it stays in view while swiping sideways
- offset the main content with a shared CSS variable that also drives team header stickiness
- remove the horizontal translate shim now that the fixed header remains aligned with the viewport

## Testing
- browser_container.run_playwright_script (rosters horizontal scroll check with username the_oracle)


------
https://chatgpt.com/codex/tasks/task_e_68ddf4172b08832e8c0f27a0762f6da2