### PR TITLE
Keep roster header synced with body scroll

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -3001,6 +3001,7 @@ const wrTeStatOrder = [
                 filterTeamsByQuery(compareSearchInput.value);
             }
             adjustStickyHeaders();
+            syncRosterHeaderPosition();
         }
 
         function createDepthChartTeamCard(team) {
@@ -3861,6 +3862,34 @@ const wrTeStatOrder = [
             });
         }
         window.addEventListener('resize', adjustStickyHeaders);
+
+        function syncRosterHeaderPosition() {
+            const header = document.getElementById('header-container');
+            if (!header) return;
+            const isRosterPage = document.body?.dataset?.page === 'rosters';
+            if (!isRosterPage) {
+                if (header.style.transform) {
+                    header.style.transform = '';
+                }
+                return;
+            }
+            const scrollLeft = window.scrollX
+                || document.documentElement?.scrollLeft
+                || document.body?.scrollLeft
+                || 0;
+            header.style.transform = `translate3d(${scrollLeft}px, 0, 0)`;
+        }
+
+        window.addEventListener('scroll', syncRosterHeaderPosition, { passive: true });
+        if (document.body) {
+            document.body.addEventListener('scroll', syncRosterHeaderPosition, { passive: true });
+        } else {
+            window.addEventListener('DOMContentLoaded', () => {
+                document.body?.addEventListener('scroll', syncRosterHeaderPosition, { passive: true });
+            }, { once: true });
+        }
+        window.addEventListener('resize', syncRosterHeaderPosition);
+        syncRosterHeaderPosition();
 
         function showTemporaryTooltip(element, message) {
             const tooltip = document.createElement('div');

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -209,6 +209,18 @@
             background: linear-gradient(180deg, rgba(11, 11, 18, 0.2) 10%, transparent 100%);
         }
 
+        body[data-page="rosters"] #header-container {
+            left: 0;
+            right: 0;
+            max-width: none;
+            will-change: transform;
+        }
+
+        body[data-page="rosters"] #header-container .app-header {
+            width: 100%;
+            max-width: none;
+        }
+
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */
         .glass-panel {
        background-color: rgba(13, 14, 35, 0.21);
@@ -2067,7 +2079,8 @@ body { min-height: 100%; }
 
 
   /* · · Ownership: centering + width sanity (mobile-safe) · · */
-html, body { overflow-x: hidden !important; }
+body:not([data-page="rosters"]) { overflow-x: hidden !important; }
+body[data-page="rosters"] { overflow-x: auto !important; }
 main#content { align-items: stretch !important; }
 
 #playerListView { 


### PR DESCRIPTION
## Summary
- compute the roster header transform from whichever scroll container is active so it tracks horizontal movement on mobile
- listen for body scroll events alongside window scroll to keep the header controls anchored during swipes

## Testing
- ✅ browser_container.run_playwright_script (rosters horizontal scroll check with username the_oracle)


------
https://chatgpt.com/codex/tasks/task_e_68ddf4172b08832e8c0f27a0762f6da2