### PR TITLE
Stabilize roster header during horizontal scroll

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -3001,6 +3001,7 @@ const wrTeStatOrder = [
                 filterTeamsByQuery(compareSearchInput.value);
             }
             adjustStickyHeaders();
+            syncRosterHeaderPosition();
         }
 
         function createDepthChartTeamCard(team) {
@@ -3861,6 +3862,90 @@ const wrTeStatOrder = [
             });
         }
         window.addEventListener('resize', adjustStickyHeaders);
+
+        const rosterHeaderSync = (() => {
+            const state = {
+                pending: false,
+                lastOffset: null,
+                headerContainer: null,
+                headerContent: null,
+            };
+
+            const ensureHeaderNodes = () => {
+                if (!state.headerContainer || !document.body.contains(state.headerContainer)) {
+                    state.headerContainer = document.getElementById('header-container');
+                    state.headerContent = state.headerContainer?.querySelector('.app-header') || state.headerContainer;
+                }
+            };
+
+            const getHorizontalScroll = () => {
+                const docEl = document.scrollingElement || document.documentElement;
+                return window.scrollX
+                    || docEl?.scrollLeft
+                    || document.body?.scrollLeft
+                    || 0;
+            };
+
+            const applyTransform = () => {
+                state.pending = false;
+                ensureHeaderNodes();
+
+                const isRosterPage = document.body?.dataset?.page === 'rosters';
+                const headerContent = state.headerContent;
+
+                if (!isRosterPage || !headerContent) {
+                    if (headerContent?.style?.transform) {
+                        headerContent.style.transform = '';
+                    }
+                    state.lastOffset = 0;
+                    return;
+                }
+
+                const scrollLeft = Math.round(getHorizontalScroll());
+
+                if (scrollLeft === state.lastOffset) {
+                    return;
+                }
+
+                state.lastOffset = scrollLeft;
+
+                if (!scrollLeft) {
+                    headerContent.style.transform = '';
+                } else {
+                    headerContent.style.transform = `translate3d(${scrollLeft}px, 0, 0)`;
+                }
+            };
+
+            const scheduleUpdate = () => {
+                if (state.pending) return;
+                state.pending = true;
+                window.requestAnimationFrame(applyTransform);
+            };
+
+            const handleScroll = () => {
+                if (document.body?.dataset?.page !== 'rosters') return;
+                scheduleUpdate();
+            };
+
+            window.addEventListener('scroll', handleScroll, { passive: true });
+
+            const attachBodyListener = () => {
+                document.body?.addEventListener('scroll', handleScroll, { passive: true });
+            };
+
+            if (document.body) {
+                attachBodyListener();
+            } else {
+                window.addEventListener('DOMContentLoaded', attachBodyListener, { once: true });
+            }
+
+            window.addEventListener('resize', scheduleUpdate);
+            scheduleUpdate();
+
+            return {
+                refresh: scheduleUpdate,
+            };
+        })();
 
         function showTemporaryTooltip(element, message) {
             const tooltip = document.createElement('div');

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -209,6 +209,18 @@
             background: linear-gradient(180deg, rgba(11, 11, 18, 0.2) 10%, transparent 100%);
         }
 
+        body[data-page="rosters"] #header-container {
+            left: 0;
+            right: 0;
+            max-width: none;
+        }
+
+        body[data-page="rosters"] #header-container .app-header {
+            width: 100%;
+            max-width: none;
+            will-change: transform;
+        }
+
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */
         .glass-panel {
        background-color: rgba(13, 14, 35, 0.21);
@@ -2067,7 +2079,8 @@ body { min-height: 100%; }
 
 
   /* · · Ownership: centering + width sanity (mobile-safe) · · */
-html, body { overflow-x: hidden !important; }
+body:not([data-page="rosters"]) { overflow-x: hidden !important; }
+body[data-page="rosters"] { overflow-x: auto !important; }
 main#content { align-items: stretch !important; }
 
 #playerListView { 


### PR DESCRIPTION
## Summary
- throttle roster header sync with `requestAnimationFrame` and target the inner header element so it holds steady during horizontal swipes
- move the `will-change` hint to the header content to keep the translation smooth without jostling the sticky container

## Testing
- ✅ browser_container.run_playwright_script (roster header horizontal scroll check with username the_oracle)


------
https://chatgpt.com/codex/tasks/task_e_68ddf4172b08832e8c0f27a0762f6da2