### PR TITLE
Adjust roster header spacing

### DIFF
--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -229,7 +229,7 @@
         }
 
         body[data-page="rosters"] main#content {
-            padding-top: calc(var(--roster-header-height, 0px) + 0.75rem);
+            padding-top: calc(var(--roster-header-height, 0px) + 0.25rem);
         }
 
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */


### PR DESCRIPTION
## Summary
- reduce the roster page content padding so the fixed header and sticky team headers sit closer together

## Testing
- Manual validation of roster page in browser

------
https://chatgpt.com/codex/tasks/task_e_68de08498ef8832ea5594b9007bb4407