### PR TITLE
Reduce gap above roster team headers

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -3858,7 +3858,8 @@ const wrTeStatOrder = [
             const headerHeight = headerContainer.offsetHeight;
             const teamHeaders = document.querySelectorAll('.team-header-item');
             teamHeaders.forEach(header => {
-                header.style.top = `${headerHeight}px`;
+                header.style.removeProperty('top');
+                header.style.setProperty('--team-header-top', `${headerHeight}px`);
             });
 
             const isRosterPage = document.body?.dataset?.page === 'rosters';

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -889,6 +889,9 @@
       box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
       position: sticky;
       z-index: 1;
+      --team-header-offset: var(--team-header-top, var(--roster-header-height, 0px));
+      top: var(--team-header-offset);
+      margin-top: calc(-1 * var(--team-header-offset));
 }
         .team-header-item:hover {
             box-shadow: 0 0 5px #7300ff;


### PR DESCRIPTION
## Summary
- derive a shared CSS variable for sticky roster headers instead of hard-coding their offset
- use the shared variable to negate the initial sticky offset so headers sit flush with the roster grid

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de08498ef8832ea5594b9007bb4407