### PR TITLE
Smooth roster header horizontal sync

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -3001,6 +3001,7 @@ const wrTeStatOrder = [
                 filterTeamsByQuery(compareSearchInput.value);
             }
             adjustStickyHeaders();
+            applyRosterHeaderSync();
         }
 
         function createDepthChartTeamCard(team) {
@@ -3861,6 +3862,106 @@ const wrTeStatOrder = [
             });
         }
         window.addEventListener('resize', adjustStickyHeaders);
+
+        let rosterHeaderSyncFrame = null;
+        let rosterHeaderLastX = null;
+        let rosterHeaderScrollHost = null;
+
+        function selectRosterScrollHost() {
+            if (rosterContainer && (rosterContainer.scrollWidth - rosterContainer.clientWidth > 1)) {
+                return rosterContainer;
+            }
+            const scroller = document.scrollingElement || document.documentElement || document.body;
+            if (scroller && (scroller.scrollWidth - scroller.clientWidth > 1)) {
+                return scroller;
+            }
+            return typeof window !== 'undefined' ? window : null;
+        }
+
+        function readScrollLeft(host) {
+            if (!host) return 0;
+            if (host === window) {
+                return window.scrollX || window.pageXOffset || 0;
+            }
+            if (host === document || host === document.body) {
+                return document.body?.scrollLeft || 0;
+            }
+            if (host === document.scrollingElement || host === document.documentElement) {
+                return (document.scrollingElement || document.documentElement)?.scrollLeft || 0;
+            }
+            return host.scrollLeft || 0;
+        }
+
+        function applyRosterHeaderSync() {
+            rosterHeaderSyncFrame = null;
+            const header = document.getElementById('header-container');
+            if (!header) return;
+
+            const isRosterPage = document.body?.dataset?.page === 'rosters';
+            if (!isRosterPage) {
+                if (header.style.transform) {
+                    header.style.transform = '';
+                }
+                rosterHeaderLastX = null;
+                rosterHeaderScrollHost = null;
+                return;
+            }
+
+            if (!rosterHeaderScrollHost) {
+                rosterHeaderScrollHost = selectRosterScrollHost();
+            }
+
+            const rawScrollLeft = readScrollLeft(rosterHeaderScrollHost);
+            const scrollLeft = Math.abs(rawScrollLeft) < 0.1 ? 0 : rawScrollLeft;
+
+            if (rosterHeaderLastX !== null && Math.abs(rosterHeaderLastX - scrollLeft) < 0.1) {
+                return;
+            }
+
+            rosterHeaderLastX = scrollLeft;
+
+            if (!scrollLeft) {
+                header.style.transform = '';
+                return;
+            }
+
+            header.style.transform = `translateX(${scrollLeft}px)`;
+        }
+
+        function scheduleRosterHeaderSync(host) {
+            if (host) {
+                rosterHeaderScrollHost = host === document ? document.scrollingElement : host;
+            }
+            if (rosterHeaderSyncFrame !== null) {
+                return;
+            }
+            rosterHeaderSyncFrame = requestAnimationFrame(applyRosterHeaderSync);
+        }
+
+        const rosterScrollTargets = [];
+        if (typeof window !== 'undefined') {
+            rosterScrollTargets.push({ target: window, host: window });
+        }
+        if (rosterContainer) {
+            rosterScrollTargets.push({ target: rosterContainer, host: rosterContainer });
+        }
+        const rosterDocScroller = document.scrollingElement || document.documentElement || null;
+        if (rosterDocScroller && rosterDocScroller !== window && rosterDocScroller !== document.body) {
+            rosterScrollTargets.push({ target: rosterDocScroller, host: rosterDocScroller });
+        }
+
+        rosterScrollTargets.forEach(({ target, host }) => {
+            if (!target || typeof target.addEventListener !== 'function') {
+                return;
+            }
+            const handler = () => scheduleRosterHeaderSync(host);
+            target.addEventListener('scroll', handler, { passive: true });
+        });
+        window.addEventListener('resize', () => {
+            rosterHeaderScrollHost = null;
+            scheduleRosterHeaderSync();
+        });
+        applyRosterHeaderSync();
 
         function showTemporaryTooltip(element, message) {
             const tooltip = document.createElement('div');

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -209,6 +209,18 @@
             background: linear-gradient(180deg, rgba(11, 11, 18, 0.2) 10%, transparent 100%);
         }
 
+        body[data-page="rosters"] #header-container {
+            left: 0;
+            right: 0;
+            max-width: none;
+            will-change: transform;
+        }
+
+        body[data-page="rosters"] #header-container .app-header {
+            width: 100%;
+            max-width: none;
+        }
+
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */
         .glass-panel {
        background-color: rgba(13, 14, 35, 0.21);
@@ -2067,7 +2079,8 @@ body { min-height: 100%; }
 
 
   /* · · Ownership: centering + width sanity (mobile-safe) · · */
-html, body { overflow-x: hidden !important; }
+body:not([data-page="rosters"]) { overflow-x: hidden !important; }
+body[data-page="rosters"] { overflow-x: auto !important; }
 main#content { align-items: stretch !important; }
 
 #playerListView { 


### PR DESCRIPTION
## Summary
- throttle roster header syncing with requestAnimationFrame and reuse the last applied offset to stop the horizontal bobble
- derive the scroll offset from whichever container is moving and reuse it when rosters render so the header stays locked in place
- tighten scroll host selection and ignore sub-pixel deltas while translating the header so it stays steady during horizontal swipes

## Testing
- ✅ browser_container.run_playwright_script (rosters horizontal scroll check with username the_oracle)


------
https://chatgpt.com/codex/tasks/task_e_68ddf4172b08832e8c0f27a0762f6da2