### PR TITLE
Reduce roster sticky header gap

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -3856,9 +3856,14 @@ const wrTeStatOrder = [
             const headerContainer = document.getElementById('header-container');
             if (!headerContainer) return;
             const headerHeight = headerContainer.offsetHeight;
+            const rootStyles = getComputedStyle(document.documentElement);
+            const rosterGapRaw = rootStyles.getPropertyValue('--roster-header-gap');
+            const rosterGap = Number.parseFloat(rosterGapRaw) || 0;
+            const stickyOffset = Math.max(headerHeight - rosterGap, 0);
+
             const teamHeaders = document.querySelectorAll('.team-header-item');
             teamHeaders.forEach(header => {
-                header.style.top = `${headerHeight}px`;
+                header.style.top = `${stickyOffset}px`;
             });
 
             const isRosterPage = document.body?.dataset?.page === 'rosters';

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -51,6 +51,7 @@
 
       :root {
         --roster-header-height: 0px;
+        --roster-header-gap: 8px;
       }
 
       body {
@@ -229,7 +230,7 @@
         }
 
         body[data-page="rosters"] main#content {
-            padding-top: calc(var(--roster-header-height, 0px) + 0.75rem);
+            padding-top: max(calc(var(--roster-header-height, 0px) - var(--roster-header-gap, 0px)), 0px);
         }
 
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */


### PR DESCRIPTION
## Summary
- shrink the roster page top padding so the sticky team headers sit just below the fixed navigation
- update the sticky header adjustment logic to reuse the shared roster gap for consistent spacing while scrolling

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68de08498ef8832ea5594b9007bb4407