### PR TITLE
Further reduce roster header spacing

### DIFF
--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -229,7 +229,7 @@
         }
 
         body[data-page="rosters"] main#content {
-            padding-top: calc(var(--roster-header-height, 0px) + 0.75rem);
+            padding-top: max(0px, calc(var(--roster-header-height, 0px) - 2rem));
         }
 
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */


### PR DESCRIPTION
## Summary
- reduce the roster page content offset so the sticky team headers sit closer to the fixed navigation

## Testing
- Manual verification on the rosters page using username `the_oracle`


------
https://chatgpt.com/codex/tasks/task_e_68de08498ef8832ea5594b9007bb4407