### PR TITLE
Further tighten roster sticky header spacing

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -3856,9 +3856,17 @@ const wrTeStatOrder = [
             const headerContainer = document.getElementById('header-container');
             if (!headerContainer) return;
             const headerHeight = headerContainer.offsetHeight;
+            const rootStyles = getComputedStyle(document.documentElement);
+            // The gap is controlled via the --roster-header-gap custom property so designers can fine-tune spacing without
+            // touching the JavaScript. Update the value in styles.css to move the sticky team headers closer to or farther
+            // from the global header.
+            const rosterGapRaw = rootStyles.getPropertyValue('--roster-header-gap');
+            const rosterGap = Number.parseFloat(rosterGapRaw) || 0;
+            const stickyOffset = Math.max(headerHeight - rosterGap, 0);
+
             const teamHeaders = document.querySelectorAll('.team-header-item');
             teamHeaders.forEach(header => {
-                header.style.top = `${headerHeight}px`;
+                header.style.top = `${stickyOffset}px`;
             });
 
             const isRosterPage = document.body?.dataset?.page === 'rosters';

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -51,6 +51,7 @@
 
       :root {
         --roster-header-height: 0px;
+        --roster-header-gap: 12px; /* Adjust this value to change the vertical gap beneath the global header on roster pages */
       }
 
       body {
@@ -229,7 +230,7 @@
         }
 
         body[data-page="rosters"] main#content {
-            padding-top: calc(var(--roster-header-height, 0px) + 0.75rem);
+            padding-top: max(calc(var(--roster-header-height, 0px) - var(--roster-header-gap, 0px)), 0px);
         }
 
 /* ⬇︎  UTILITY CLASSES  ⬇︎ */


### PR DESCRIPTION
## Summary
- increase the shared roster header gap variable so sticky team headers sit closer to the global header
- document in CSS and JavaScript how to tweak the gap for future fine-tuning

## Testing
- Not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68de08498ef8832ea5594b9007bb4407