### PR TITLE
Fix roster header offset when exiting trade preview

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -546,6 +546,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             if (appHeader) {
                 appHeader.classList.toggle('preview-active', state.isCompareMode);
             }
+            requestAnimationFrame(() => {
+                adjustStickyHeaders();
+                syncRosterHeaderPosition();
+                if (!state.isCompareMode) {
+                    window.scrollTo({ top: 0, behavior: 'auto' });
+                    requestAnimationFrame(syncRosterHeaderPosition);
+                }
+            });
         }
 
         function handleCompareClick() {


### PR DESCRIPTION
## Summary
- recalculate sticky roster headers after toggling trade preview state
- ensure the page scrolls back to the top when leaving trade preview to avoid headers hiding behind the page chrome

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68de127ebbe4832e92cbadf172143cff