### PR TITLE
Ensure roster loading respects header offset and scroll trade preview transitions

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -534,6 +534,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                         rosterView.classList.add('is-trade-mode');
                         rosterGrid.classList.add('is-preview-mode');
                         updateHeaderPreviewState(); // call before render
+                        window.scrollTo(0, 0); // scroll to top
                         renderAllTeamData(state.currentTeams);
                         renderTradeBlock();
                     }
@@ -559,6 +560,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 clearTrade();
                 window.scrollTo(0, 0); // scroll to top
             } else {
+                window.scrollTo(0, 0); // scroll to top
                 renderTradeBlock();
             }
             renderAllTeamData(state.currentTeams);
@@ -1635,7 +1637,7 @@ const SEASON_META_HEADERS = {
             const teams = rosters.map(roster => {
                 const owner = userMap[roster.owner_id];
                 const allPlayers = roster.players || [];
-                
+
                 const starterIds = roster.starters || [];
                 const starters = starterIds.map((playerId, index) => {
                     const slot = rosterPositions[index] || 'FLEX';
@@ -1656,6 +1658,7 @@ const SEASON_META_HEADERS = {
                 return {
                     isUserTeam,
                     teamName: owner?.display_name || `Team ${roster.roster_id}`,
+                    record: formatTeamRecord(roster.settings),
                     starters,
                     bench: bench.map(p => getPlayerData(p, 'BN')).sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                     taxi,
@@ -1663,7 +1666,7 @@ const SEASON_META_HEADERS = {
                     allPlayers: allPlayers.map(pId => getPlayerData(pId, ''))
                 };
             });
-            
+
             state.currentTeams = teams;
 
             return teams.sort((a, b) => {
@@ -1671,6 +1674,19 @@ const SEASON_META_HEADERS = {
                 if (b.isUserTeam) return 1;
                 return a.teamName.localeCompare(b.teamName);
             });
+        }
+
+        function formatTeamRecord(settings = {}) {
+            const wins = Number.isFinite(settings?.wins) ? settings.wins : null;
+            const losses = Number.isFinite(settings?.losses) ? settings.losses : null;
+            const ties = Number.isFinite(settings?.ties) ? settings.ties : 0;
+
+            if (wins === null || losses === null) {
+                return null;
+            }
+
+            const baseRecord = `${wins}-${losses}`;
+            return ties ? `${baseRecord}-${ties}` : baseRecord;
         }
         
         function getOwnedPicks(rosterId, tradedPicks, leagueInfo) {
@@ -2987,11 +3003,23 @@ const wrTeStatOrder = [
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
-                header.title = team.teamName;
+
+                if (team.record) {
+                    header.title = `${team.teamName} (${team.record})`;
+                } else {
+                    header.title = team.teamName;
+                }
 
 
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
+
+                if (team.record) {
+                    const recordSpan = document.createElement('span');
+                    recordSpan.className = 'team-record';
+                    recordSpan.textContent = `(${team.record})`;
+                    header.appendChild(recordSpan);
+                }
 
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
 
@@ -3860,6 +3888,9 @@ const wrTeStatOrder = [
             if (!headerContainer) return;
             const headerHeight = headerContainer.offsetHeight;
             const rootStyles = getComputedStyle(document.documentElement);
+            // The gap is controlled via the --roster-header-gap custom property so designers can fine-tune spacing without
+            // touching the JavaScript. Update the value in styles.css to move the sticky team headers closer to or farther
+            // from the global header.
             const rosterGapRaw = rootStyles.getPropertyValue('--roster-header-gap');
             const rosterGap = Number.parseFloat(rosterGapRaw) || 0;
             const stickyOffset = Math.max(headerHeight - rosterGap, 0);
@@ -3990,6 +4021,9 @@ const wrTeStatOrder = [
 
         function setLoading(isLoading, message = 'Loading...') {
             welcomeScreen?.classList.add('hidden');
+            if (document.body?.dataset?.page === 'rosters') {
+                adjustStickyHeaders();
+            }
             const buttons = [fetchRostersButton, fetchOwnershipButton].filter(Boolean);
             if (isLoading) {
                 const msgEl = loadingIndicator.querySelector('.loading-message'); if (msgEl) { msgEl.textContent = message; } else { loadingIndicator.textContent = message; }

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -51,7 +51,7 @@
 
       :root {
         --roster-header-height: 0px;
-        --roster-header-gap: 8px;
+        --roster-header-gap: 12px; /* Adjust this value to change the vertical gap beneath the global header on roster pages */
       }
 
       body {
@@ -870,15 +870,15 @@
 }
 		
        .team-header-item {
-      display: flex;
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
       align-items: center;
-      justify-content: center;
-      gap: 0.5rem;
-      font-size: 0.75rem;
+      column-gap: 0.25rem;
+      font-size: 0.7rem;
       font-weight: 500;
       color: #d0d1ee;
       text-align: center;
-      padding: 0.4rem 0.5rem;
+      padding: 0.32rem 0.45rem;
       cursor: pointer;
     
       /* · · Glass look to match filter groups · · */
@@ -1089,7 +1089,7 @@
             cursor: pointer;
             position: relative;
             transition: all 0.2s ease-in-out;
-            flex-shrink: 0;
+            justify-self: start;
         }
         .team-compare-checkbox.selected {
             border-color: var(--color-accent-primary);
@@ -2703,10 +2703,21 @@ border: 1px solid rgb(169 178 227 / 9%);
 }
 
 .team-header-item .team-name {
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 90px;
+    text-align: center;
+    justify-self: center;
+}
+
+.team-header-item .team-record {
+    font-size: 0.58rem;
+    color: #9ea5d8;
+    white-space: nowrap;
+    justify-self: start;
 }
 
 #analyzeLeagueButton {


### PR DESCRIPTION
## Summary
- update loading state handling on the roster page to recalculate sticky header offsets so the panel no longer sits beneath the fixed header
- scroll to the top whenever trade preview mode is toggled on through team header taps or the compare button

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de217acb78832ea4cba0fe66c8b41a