### PR TITLE
Improve roster header scroll behavior and desktop alignment

### DIFF
--- a/DHP2_DeployDraft2.11/scripts/app.js
+++ b/DHP2_DeployDraft2.11/scripts/app.js
@@ -495,6 +495,59 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
         
         // --- Compare & Trade Logic ---
+        function scrollViewportToTop({ behavior = 'smooth' } = {}) {
+            const performScroll = () => {
+                const scrollOptions = { top: 0, behavior };
+                let didScroll = false;
+
+                if (typeof window.scrollTo === 'function') {
+                    try {
+                        window.scrollTo(scrollOptions);
+                        didScroll = true;
+                    } catch (error) {
+                        window.scrollTo(0, 0);
+                        didScroll = true;
+                    }
+                }
+
+                const extraTargets = [
+                    document.scrollingElement,
+                    document.documentElement,
+                    document.body,
+                    document.getElementById('content')
+                ];
+
+                extraTargets.forEach(target => {
+                    if (!target) return;
+
+                    if (typeof target.scrollTo === 'function') {
+                        try {
+                            target.scrollTo(scrollOptions);
+                            didScroll = true;
+                            return;
+                        } catch (error) {
+                            // fall back to setting scrollTop below
+                        }
+                    }
+
+                    if (typeof target.scrollTop === 'number') {
+                        target.scrollTop = 0;
+                        didScroll = true;
+                    }
+                });
+
+                if (!didScroll) {
+                    document.getElementById('header-container')?.scrollIntoView({ behavior, block: 'start', inline: 'nearest' });
+                }
+            };
+
+            if (typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(() => performScroll());
+            } else {
+                performScroll();
+            }
+        }
+
         function handleTeamSelect(e) {
             const header = e.target.closest('.team-header-item');
             if (header) {
@@ -513,7 +566,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     rosterGrid.classList.remove('is-preview-mode');
 
                     clearTrade();
-                    window.scrollTo(0, 0); // scroll to top
+                    scrollViewportToTop();
                     updateHeaderPreviewState(); // call before render
                     renderAllTeamData(state.currentTeams);
 
@@ -534,6 +587,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                         rosterView.classList.add('is-trade-mode');
                         rosterGrid.classList.add('is-preview-mode');
                         updateHeaderPreviewState(); // call before render
+                        scrollViewportToTop();
                         renderAllTeamData(state.currentTeams);
                         renderTradeBlock();
                     }
@@ -557,8 +611,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             updateHeaderPreviewState(); // call before render
             if (!state.isCompareMode) {
                 clearTrade();
-                window.scrollTo(0, 0); // scroll to top
+                scrollViewportToTop();
             } else {
+                scrollViewportToTop();
                 renderTradeBlock();
             }
             renderAllTeamData(state.currentTeams);
@@ -576,10 +631,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             state.isCompareMode = false;
             rosterView.classList.remove('is-trade-mode');
             rosterGrid.classList.remove('is-preview-mode');
-            
+
             updateCompareButtonState();
             clearTrade();
-            window.scrollTo(0, 0); // scroll to top
+            scrollViewportToTop();
             updateHeaderPreviewState(); // call before render
             if (state.currentTeams) {
                 renderAllTeamData(state.currentTeams);
@@ -1635,7 +1690,7 @@ const SEASON_META_HEADERS = {
             const teams = rosters.map(roster => {
                 const owner = userMap[roster.owner_id];
                 const allPlayers = roster.players || [];
-                
+
                 const starterIds = roster.starters || [];
                 const starters = starterIds.map((playerId, index) => {
                     const slot = rosterPositions[index] || 'FLEX';
@@ -1656,6 +1711,7 @@ const SEASON_META_HEADERS = {
                 return {
                     isUserTeam,
                     teamName: owner?.display_name || `Team ${roster.roster_id}`,
+                    record: formatTeamRecord(roster.settings),
                     starters,
                     bench: bench.map(p => getPlayerData(p, 'BN')).sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                     taxi,
@@ -1663,7 +1719,7 @@ const SEASON_META_HEADERS = {
                     allPlayers: allPlayers.map(pId => getPlayerData(pId, ''))
                 };
             });
-            
+
             state.currentTeams = teams;
 
             return teams.sort((a, b) => {
@@ -1671,6 +1727,19 @@ const SEASON_META_HEADERS = {
                 if (b.isUserTeam) return 1;
                 return a.teamName.localeCompare(b.teamName);
             });
+        }
+
+        function formatTeamRecord(settings = {}) {
+            const wins = Number.isFinite(settings?.wins) ? settings.wins : null;
+            const losses = Number.isFinite(settings?.losses) ? settings.losses : null;
+            const ties = Number.isFinite(settings?.ties) ? settings.ties : 0;
+
+            if (wins === null || losses === null) {
+                return null;
+            }
+
+            const baseRecord = `${wins}-${losses}`;
+            return ties ? `${baseRecord}-${ties}` : baseRecord;
         }
         
         function getOwnedPicks(rosterId, tradedPicks, leagueInfo) {
@@ -2987,11 +3056,23 @@ const wrTeStatOrder = [
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
-                header.title = team.teamName;
+
+                if (team.record) {
+                    header.title = `${team.teamName} (${team.record})`;
+                } else {
+                    header.title = team.teamName;
+                }
 
 
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
+
+                if (team.record) {
+                    const recordSpan = document.createElement('span');
+                    recordSpan.className = 'team-record';
+                    recordSpan.textContent = `(${team.record})`;
+                    header.appendChild(recordSpan);
+                }
 
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
 
@@ -3860,6 +3941,9 @@ const wrTeStatOrder = [
             if (!headerContainer) return;
             const headerHeight = headerContainer.offsetHeight;
             const rootStyles = getComputedStyle(document.documentElement);
+            // The gap is controlled via the --roster-header-gap custom property so designers can fine-tune spacing without
+            // touching the JavaScript. Update the value in styles.css to move the sticky team headers closer to or farther
+            // from the global header.
             const rosterGapRaw = rootStyles.getPropertyValue('--roster-header-gap');
             const rosterGap = Number.parseFloat(rosterGapRaw) || 0;
             const stickyOffset = Math.max(headerHeight - rosterGap, 0);
@@ -3990,6 +4074,9 @@ const wrTeStatOrder = [
 
         function setLoading(isLoading, message = 'Loading...') {
             welcomeScreen?.classList.add('hidden');
+            if (document.body?.dataset?.page === 'rosters') {
+                adjustStickyHeaders();
+            }
             const buttons = [fetchRostersButton, fetchOwnershipButton].filter(Boolean);
             if (isLoading) {
                 const msgEl = loadingIndicator.querySelector('.loading-message'); if (msgEl) { msgEl.textContent = message; } else { loadingIndicator.textContent = message; }

--- a/DHP2_DeployDraft2.11/styles/styles.css
+++ b/DHP2_DeployDraft2.11/styles/styles.css
@@ -51,7 +51,7 @@
 
       :root {
         --roster-header-height: 0px;
-        --roster-header-gap: 8px;
+        --roster-header-gap: 12px; /* Adjust this value to change the vertical gap beneath the global header on roster pages */
       }
 
       body {
@@ -839,15 +839,15 @@
   }
 }
 /* ⬇︎ ROSTER VIEW  ⬇︎ */
-        #rosterContainer { 
+        #rosterContainer {
             padding: 1px;
         }
-        #rosterGrid { 
-            display: flex; 
-            flex-direction: row; 
-            flex-wrap: nowrap; 
+        #rosterGrid {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
             gap: 2px;
-            min-width: min-content; 
+            min-width: min-content;
             padding-bottom: 1rem; /* For scrollbar clearance */
 
         }
@@ -864,21 +864,27 @@
             border-radius: 8px;                   /* match header */
         }
 
+@media (min-width: 1024px) {
+    body[data-page="rosters"] #rosterGrid {
+        justify-content: center;
+    }
+}
+
 /* ⬇︎  ENTIRE COLUMN GLOW  ⬇︎ */
 .roster-column:has(.team-compare-checkbox.selected) {
     box-shadow: inset 0 0 2px #6300ff55, inset 0 0 38px #5300ff35;          /* same highlight as header */
 }
 		
        .team-header-item {
-      display: flex;
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
       align-items: center;
-      justify-content: center;
-      gap: 0.5rem;
-      font-size: 0.75rem;
+      column-gap: 0.25rem;
+      font-size: 0.7rem;
       font-weight: 500;
       color: #d0d1ee;
       text-align: center;
-      padding: 0.4rem 0.5rem;
+      padding: 0.32rem 0.45rem;
       cursor: pointer;
     
       /* · · Glass look to match filter groups · · */
@@ -1089,7 +1095,7 @@
             cursor: pointer;
             position: relative;
             transition: all 0.2s ease-in-out;
-            flex-shrink: 0;
+            justify-self: start;
         }
         .team-compare-checkbox.selected {
             border-color: var(--color-accent-primary);
@@ -2703,10 +2709,21 @@ border: 1px solid rgb(169 178 227 / 9%);
 }
 
 .team-header-item .team-name {
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 90px;
+    text-align: center;
+    justify-self: center;
+}
+
+.team-header-item .team-record {
+    font-size: 0.58rem;
+    color: #9ea5d8;
+    white-space: nowrap;
+    justify-self: start;
 }
 
 #analyzeLeagueButton {


### PR DESCRIPTION
## Summary
- harden the roster trade preview scroll helper so it targets every scrollable container and runs after layout for consistent top-of-page jumps
- restore the original roster column sticky behavior while centering the grid on desktop screens without affecting mobile spacing

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de217acb78832ea4cba0fe66c8b41a