### PR TITLE
Update roster cards to show FPTS ranks and adjust PPG display

### DIFF
--- a/DHP2_Centered_desktop/rosters/rosters.html
+++ b/DHP2_Centered_desktop/rosters/rosters.html
@@ -158,7 +158,7 @@
 </div>
 <!-- Middle row: Position Rank • Age • Team tag (right aligned) -->
 <div class="player-meta-line legend-meta">
-<span class="player-pos-rank legend-pos-rank">POSITION<br/>RANK (KTC)</span>
+<span class="player-pos-rank legend-pos-rank">POSITION<br/>RANK (FPTS)</span>
 <span class="separator">•</span>
 <span><span class="player-age legend-age">AGE</span></span>
 <span class="separator">•</span>
@@ -166,10 +166,10 @@
 </div>
 <!-- Bottom row: KTC left, ADP right (no chips) -->
 <div class="player-value-line legend-bottom"><div class="legend-bottom-bg">
-<span class="kv-left"><span class="value player-ktc legend-ktc">KTC VALUE</span></span>
-<span class="kv-right"><span class="value player-adp legend-adp">ADP</span></span>
+<span class="kv-left"><span class="value player-ktc legend-ktc">KTC VALUE&nbsp;(POS RK)</span></span>
+<span class="kv-right"><span class="value player-ppg legend-ppg">PPG&nbsp;(POS RK)</span></span>
 </div></div>
-</div><div class="legend-footnote" id="rosterCardFootnote">KTC VALUE AND ADP ARE SPECIFIC TO LEAGUE SCORING / FORMAT.</div></section>
+</div><div class="legend-footnote" id="rosterCardFootnote">KTC VALUE, PPG, AND POSITION RANKS REFLECT LEAGUE-SPECIFIC SCORING.</div></section>
 <div id="loading" class="hidden">
   <div class="loading-overlay" role="alert" aria-live="polite">
     <div class="loading-scene" aria-hidden="true">

--- a/DHP2_Centered_desktop/scripts/app.js
+++ b/DHP2_Centered_desktop/scripts/app.js
@@ -3151,6 +3151,7 @@ const wrTeStatOrder = [
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
             const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
             const fullPlayer = state.players?.[player.id];
+            const playerRanks = calculatePlayerStatsAndRanks(player.id) || getDefaultPlayerRanks();
             const firstName = (player.first_name || fullPlayer?.first_name || '').trim();
             const lastName = (player.last_name || fullPlayer?.last_name || '').trim();
             const nameCandidates = [
@@ -3182,9 +3183,8 @@ const wrTeStatOrder = [
                 row.classList.add('player-selected');
             }
 
-            const adp = player.adp ? player.adp.toFixed(1) : '—';
             const ktc = player.ktc || '—';
-            
+
             const teamKey = (player.team || 'FA').toUpperCase();
             const logoKeyMap = { 'WSH': 'was', 'WAS': 'was', 'JAC': 'jax', 'LA': 'lar' };
             const normalizedKey = logoKeyMap[teamKey] || teamKey.toLowerCase();
@@ -3193,7 +3193,26 @@ const wrTeStatOrder = [
               ? `<img class="team-logo glow" src="${src}" alt="${teamKey}" width="19" height="19" loading="eager">`
               : `<div class="team-tag" style="background-color: #64748b; color: white;">FA</div>`;
 
-            const posRankColor = getPosRankColor(player.posRank);
+            const basePos = (player.pos || fullPlayer?.position || displaySlot || '').toUpperCase();
+            const fptsPosRankNumber = Number.parseInt(playerRanks.posRank, 10);
+            const hasFptsPosRank = Number.isFinite(fptsPosRankNumber) && fptsPosRankNumber > 0;
+            const fptsPosRankDisplay = hasFptsPosRank ? `${basePos}·${fptsPosRankNumber}` : basePos;
+            const posRankColor = getPosRankColor(fptsPosRankDisplay);
+            const ppgRawString = typeof playerRanks.ppg === 'string' ? playerRanks.ppg.trim() : '';
+            const numericPpgValue = typeof playerRanks.ppg === 'number'
+                ? playerRanks.ppg
+                : Number.parseFloat(ppgRawString || '');
+            const hasNumericPpgValue = Number.isFinite(numericPpgValue);
+            const hasPositivePpgValue = hasNumericPpgValue && numericPpgValue > 0;
+            const ppgValue = hasPositivePpgValue
+                ? numericPpgValue.toFixed(2)
+                : (!hasNumericPpgValue && ppgRawString && ppgRawString.toUpperCase() !== 'NA' ? ppgRawString : 'NA');
+            const rawPpgPosRankNumber = Number.parseInt(playerRanks.ppgPosRank, 10);
+            const hasPpgPosRank = Number.isFinite(rawPpgPosRankNumber) && rawPpgPosRankNumber > 0;
+            const ppgPosRankNumber = hasPpgPosRank ? rawPpgPosRankNumber : null;
+            const ktcPosRankMatch = typeof player.posRank === 'string' ? player.posRank.match(/(\d+)/) : null;
+            const rawKtcPosRankNumber = ktcPosRankMatch ? Number.parseInt(ktcPosRankMatch[1], 10) : null;
+            const ktcPosRankNumber = Number.isFinite(rawKtcPosRankNumber) && rawKtcPosRankNumber > 0 ? rawKtcPosRankNumber : null;
 
             row.innerHTML = `
                 <div class="player-main-line">
@@ -3201,22 +3220,42 @@ const wrTeStatOrder = [
                     <div class="player-name"><span class="player-name-clickable">${player.name}</span></div>
                 </div>
                 <div class="player-meta-line">
-                    <span class="player-pos-rank" style="color: ${posRankColor}; font-weight: 400;">${player.posRank || player.pos}</span>
+                    <span class="player-pos-rank" style="color: ${posRankColor}; font-weight: 400;">${fptsPosRankDisplay}</span>
                     <span class="separator">•</span>
                     <span><span class="player-age">${player.age || '?'}</span> y.o. </span>
                     <span class="separator">•</span>
                     ${teamTagHTML}
                 </div>
                 <div class="player-value-line">
-                    <span>KTC: <span class="value player-ktc">${ktc}</span></span>
-                    <span>ADP: <span class="value player-adp">${adp}</span></span>
+                    <span class="player-ktc-wrapper">KTC: <span class="value player-ktc">${ktc}</span></span>
+                    <span class="player-ppg-wrapper">PPG: <span class="value player-ppg">${ppgValue}</span></span>
                 </div>
             `;
-            
-            const ageEl = row.querySelector('.player-age'), adpEl = row.querySelector('.player-adp'), ktcEl = row.querySelector('.player-ktc');
+
+            const ageEl = row.querySelector('.player-age');
+            const ktcEl = row.querySelector('.player-ktc');
+            const ppgEl = row.querySelector('.player-ppg');
+            const playerPosRankEl = row.querySelector('.player-pos-rank');
+            if (playerPosRankEl) {
+                playerPosRankEl.textContent = fptsPosRankDisplay;
+                playerPosRankEl.style.color = posRankColor;
+            }
             if (ageEl && player.age && player.age !== '?') ageEl.style.color = getAgeColorForRoster(player.pos, parseFloat(player.age));
-            if (adpEl && player.adp) adpEl.style.color = getAdpColorForRoster(parseFloat(adp));
             if (ktcEl && player.ktc) ktcEl.style.color = getKtcColor(player.ktc);
+            if (ppgEl) {
+                ppgEl.textContent = ppgValue;
+                if (hasPositivePpgValue && typeof ppgPosRankNumber === 'number') {
+                    ppgEl.style.color = getConditionalColorByRank(ppgPosRankNumber, basePos);
+                } else if (!hasPositivePpgValue) {
+                    ppgEl.style.color = 'var(--color-text-tertiary)';
+                }
+            }
+
+            const ktcWrapper = row.querySelector('.player-ktc-wrapper');
+            if (ktcWrapper) {
+                ktcWrapper.classList.add('has-rank-annotation');
+                ktcWrapper.appendChild(createRankAnnotation(typeof ktcPosRankNumber === 'number' ? ktcPosRankNumber : 'NA'));
+            }
 
             const playerNameClickableEl = row.querySelector('.player-name-clickable');
             if (playerNameClickableEl) {

--- a/DHP2_Centered_desktop/styles/styles.css
+++ b/DHP2_Centered_desktop/styles/styles.css
@@ -1049,7 +1049,7 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            font-size: 0.65rem;
+            font-size: 0.62rem;
             color: var(--color-text-secondary);
             background: #1d223faa;
             border-radius: 6px;
@@ -1057,7 +1057,7 @@
         }
         .player-value-line .value {
             font-weight: 600;
-            font-size: 0.7rem;
+            font-size: 0.66rem;
             color: var(--color-text-primary);
         }
 
@@ -1891,6 +1891,7 @@
 }
 #rosterPlayerCardKey .legend-ktc { color: #00EBC7; font-weight: 800; }
 #rosterPlayerCardKey .legend-adp { color: #58A7FF; font-weight: 800; }
+#rosterPlayerCardKey .legend-ppg { color: #58A7FF; font-weight: 800; }
 
   /* · · External footnote below the card · · */
 #rosterCardFootnote.legend-footnote {
@@ -2351,6 +2352,7 @@ font-weight: 500 !important;
 }
 #rosterPlayerCardKey .legend-ktc{ color: #00EBC7 !important; }
 #rosterPlayerCardKey .legend-adp{ color: #58A7FF !important; }
+#rosterPlayerCardKey .legend-ppg{ color: #58A7FF !important; }
 
   /* · · Footnote · · */
 #rosterCardFootnote.legend-footnote{
@@ -3731,7 +3733,7 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
 
     .has-rank-annotation .stat-rank-annotation {
         display: inline-block;
-        font-size: 0.65em;
+        font-size: 0.72em;
         line-height: 1;
         margin-left: 0.2em;
         transform: translateY(-0.45em);


### PR DESCRIPTION
## Summary
- replace the roster card ADP display with PPG and attach FPTS position ranks to the header
- append superscript-style position rank annotations to the KTC value using existing helpers
- refresh the roster legend copy to describe FPTS ranks and the new PPG field while keeping styling consistent
- show NA with tertiary text coloring when a player has no positive PPG value instead of displaying 0.00
- tweak roster card typography to enlarge the superscript ranks and slightly reduce the KTC/PPG label and value sizing

## Testing
- http://127.0.0.1:8000/rosters/rosters.html?username=the_oracle

------
https://chatgpt.com/codex/tasks/task_e_68de47561c3c832e996c6e64bbd45f17