### PR TITLE
Update game log opponent separator to middle dot

### DIFF
--- a/DHP2.51/scripts/app.js
+++ b/DHP2.51/scripts/app.js
@@ -2024,7 +2024,7 @@ const wrTeStatOrder = [
                 if (opponent) {
                     const opponentSpan = document.createElement('span');
                     opponentSpan.className = 'week-opponent-label';
-                    opponentSpan.textContent = `(${opponent})`;
+                    opponentSpan.textContent = ` · ${opponent}`;
                     const color = getOpponentRankColor(weekStats.stats?.opponent_rank);
                     if (color) opponentSpan.style.color = color;
                     weekTd.appendChild(opponentSpan);


### PR DESCRIPTION
## Summary
- remove parentheses from opponent labels in the game logs table
- ensure a middle dot separates the week number and opponent name for improved readability

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df9eadf264832e9ce569d0774fc3c0