### PR TITLE
Update game log opponent separator to middle dot

### DIFF
--- a/DHP2.51/scripts/app.js
+++ b/DHP2.51/scripts/app.js
@@ -2024,9 +2024,15 @@ const wrTeStatOrder = [
                 if (opponent) {
                     const opponentSpan = document.createElement('span');
                     opponentSpan.className = 'week-opponent-label';
-                    opponentSpan.textContent = `(${opponent})`;
-                    const color = getOpponentRankColor(weekStats.stats?.opponent_rank);
+                    opponentSpan.textContent = ` · ${opponent}`;
+                    const opponentRank = weekStats.stats?.opponent_rank;
+                    const color = getOpponentRankColor(opponentRank);
                     if (color) opponentSpan.style.color = color;
+                    if (opponentRank !== undefined && opponentRank !== null && opponentRank !== '') {
+                        opponentSpan.classList.add('has-rank-annotation');
+                        opponentSpan.appendChild(document.createTextNode(' '));
+                        opponentSpan.appendChild(createRankAnnotation(opponentRank));
+                    }
                     weekTd.appendChild(opponentSpan);
                 }
                 row.appendChild(weekTd);


### PR DESCRIPTION
## Summary
- remove parentheses from opponent labels in the game logs table
- ensure a middle dot separates the week number and opponent name for improved readability
- append opponent rank annotations from the vsRK column styled like stat footer ranks

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df9eadf264832e9ce569d0774fc3c0