### PR TITLE
Show opponent ranks in game log labels

### DIFF
--- a/DHP2.51/scripts/app.js
+++ b/DHP2.51/scripts/app.js
@@ -2024,9 +2024,18 @@ const wrTeStatOrder = [
                 if (opponent) {
                     const opponentSpan = document.createElement('span');
                     opponentSpan.className = 'week-opponent-label';
-                    opponentSpan.textContent = `(${opponent})`;
+                    opponentSpan.textContent = ` · ${opponent}`;
                     const color = getOpponentRankColor(weekStats.stats?.opponent_rank);
                     if (color) opponentSpan.style.color = color;
+
+                    const opponentRank = weekStats.stats?.opponent_rank;
+                    const opponentRankDisplay = getRankDisplayText(opponentRank);
+                    if (opponentRankDisplay !== 'NA') {
+                        opponentSpan.classList.add('has-rank-annotation');
+                        const rankAnnotation = createRankAnnotation(opponentRank);
+                        opponentSpan.appendChild(rankAnnotation);
+                    }
+
                     weekTd.appendChild(opponentSpan);
                 }
                 row.appendChild(weekTd);


### PR DESCRIPTION
## Summary
- append opponent ranks to weekly opponent labels in the game log modal
- reuse the stat footer rank annotation styling so the rank appears small, parenthetical, and elevated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9eadf264832e9ce569d0774fc3c0