### PR TITLE
Display opponent ranks without parentheses in game logs

### DIFF
--- a/DHP2.51/scripts/app.js
+++ b/DHP2.51/scripts/app.js
@@ -1441,10 +1441,11 @@ const SEASON_META_HEADERS = {
             return rankStr;
         }
 
-        function createRankAnnotation(rank) {
+        function createRankAnnotation(rank, { wrapInParens = true } = {}) {
             const span = document.createElement('span');
             span.className = 'stat-rank-annotation';
-            span.textContent = `(${getRankDisplayText(rank)})`;
+            const displayText = getRankDisplayText(rank);
+            span.textContent = wrapInParens ? `(${displayText})` : displayText;
             return span;
         }
 
@@ -2024,9 +2025,18 @@ const wrTeStatOrder = [
                 if (opponent) {
                     const opponentSpan = document.createElement('span');
                     opponentSpan.className = 'week-opponent-label';
-                    opponentSpan.textContent = `(${opponent})`;
+                    opponentSpan.textContent = ` · ${opponent}`;
                     const color = getOpponentRankColor(weekStats.stats?.opponent_rank);
                     if (color) opponentSpan.style.color = color;
+
+                    const opponentRank = weekStats.stats?.opponent_rank;
+                    const opponentRankDisplay = getRankDisplayText(opponentRank);
+                    if (opponentRankDisplay !== 'NA') {
+                        opponentSpan.classList.add('has-rank-annotation');
+                        const rankAnnotation = createRankAnnotation(opponentRank, { wrapInParens: false });
+                        opponentSpan.appendChild(rankAnnotation);
+                    }
+
                     weekTd.appendChild(opponentSpan);
                 }
                 row.appendChild(weekTd);


### PR DESCRIPTION
## Summary
- add an option to the rank annotation helper so most contexts continue using parentheses
- render game log opponent rank annotations without parentheses while keeping the elevated styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9eadf264832e9ce569d0774fc3c0